### PR TITLE
Refactor response to batch owner request

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ This framework helps to resolve a decentralized domain name such as `brad.crypto
 
 ## Cocoa Pods
 ```ruby
-pod 'UnstoppableDomainsResolution', '~> 0.1.3'
+pod 'UnstoppableDomainsResolution', '~> 0.1.4'
 ```
 ## Swift Package Manager
 ```swift
 package.dependencies.append(
-    .package(url: "https://github.com/unstoppabledomains/resolution-swift", from: "0.1.3")
+    .package(url: "https://github.com/unstoppabledomains/resolution-swift", from: "0.1.4")
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ package.dependencies.append(
  ```
  
  ## Batch request of owners
- In the version 0.1.3 there was introduced a method `batchOwners(domains: _, completion: _ )` that adds additional convenience to query the owners of the array of domains. The domains must be only CNS-compatible (other kind of domains will throw `ResolutionError.methodNotSupported`). The result will return only if all domains are resolved.
+ In the version 0.1.3 there was introduced a method `batchOwners(domains: _, completion: _ )` that adds additional convenience to query the owners of the array of domains. The domains must be only CNS-compatible (other kind of domains will throw `ResolutionError.methodNotSupported`). As opposed to the single `owner(domain: _, completion: _)` method, this batch request will return the array of owners `[String?]`: if the the domain is not registered, the related array element of the response will be `nil` without throwing an error.
  
  ```swift
  
  resolution.batchOwners(domains: ["brad.crypto", "otherbrad.crypto"]) { result in
      switch result {
      case .success(let returnValue):
-           // returnValue = <array of owners's addresses>
+           // returnValue: [String?] = <array of owners's addresses>
          let domainOwner = returnValue
      case .failure(let error):
          XCTFail("Expected owner, but got \(error)")

--- a/Sources/UnstoppableDomainsResolution/ABI/ABICoder.swift
+++ b/Sources/UnstoppableDomainsResolution/ABI/ABICoder.swift
@@ -11,6 +11,12 @@ import EthereumABI
 
 typealias ABIContract = [ABI.Element]
 
+enum ABICoderError: Error {
+    case wrongABIInterfaceForMethod(method: String)
+    case couldNotEncode(method: String, args: [Any])
+    case couldNotDecode(method: String, value: String)
+}
+
 // swiftlint:disable identifier_name cyclomatic_complexity
 internal class ABICoder {
     let abi: ABIContract
@@ -27,12 +33,6 @@ internal class ABICoder {
             }
         }
         return toReturn
-    }
-
-    enum ABICoderError: Error {
-        case wrongABIInterfaceForMethod(method: String)
-        case couldNotEncode(method: String, args: [Any])
-        case couldNotDecode(method: String, value: String)
     }
 
     init(_ abi: ABIContract) {

--- a/Sources/UnstoppableDomainsResolution/APIRequest.swift
+++ b/Sources/UnstoppableDomainsResolution/APIRequest.swift
@@ -35,19 +35,23 @@ struct APIRequest {
     }
 
     func post(_ body: JsonRpcPayload, completion: @escaping(Result<JsonRpcResponseArray, APIError>) -> Void ) throws {
-        networking.makeHttpPostRequest(url: self.url,
-                                       httpMethod: "POST",
-                                       httpHeaderContentType: "application/json",
-                                       httpBody: try JSONEncoder().encode(body),
-                                       completion: completion)
+        do {
+            networking.makeHttpPostRequest(url: self.url,
+                                           httpMethod: "POST",
+                                           httpHeaderContentType: "application/json",
+                                           httpBody: try JSONEncoder().encode(body),
+                                           completion: completion)
+        } catch { throw APIError.encodingError }
     }
     
     func post(_ bodyArray: [JsonRpcPayload], completion: @escaping(Result<JsonRpcResponseArray, APIError>) -> Void ) throws {
-        networking.makeHttpPostRequest(url: self.url,
-                                       httpMethod: "POST",
-                                       httpHeaderContentType: "application/json",
-                                       httpBody: try JSONEncoder().encode(bodyArray),
-                                       completion: completion)
+        do {
+            networking.makeHttpPostRequest(url: self.url,
+                                           httpMethod: "POST",
+                                           httpHeaderContentType: "application/json",
+                                           httpBody: try JSONEncoder().encode(bodyArray),
+                                           completion: completion)
+        } catch { throw APIError.encodingError }
     }
 }
 

--- a/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
@@ -55,11 +55,11 @@ internal class CNS: CommonNamingService, NamingService {
     
     func batchOwners(domains: [String]) throws -> [String?] {
         let tokenIds = domains.map { super.namehash(domain: $0) }
-        let res: [IdentifiableResult<Any>]
+        let res: [IdentifiableResult<Any?>]
         do {
             res = try self.getBatchData(keys: [Contract.OWNER_KEY], for: tokenIds)
         } catch {
-            throw ResolutionError.unregisteredDomain
+            throw error
         }
         
         let rec = res.sorted(by: {Int($0.id)! < Int($1.id)!})
@@ -169,7 +169,7 @@ internal class CNS: CommonNamingService, NamingService {
         throw ResolutionError.proxyReaderNonInitialized
     }
     
-    private func getBatchData(keys: [String], for tokenIds: [String]) throws -> [IdentifiableResult<Any>] {
+    private func getBatchData(keys: [String], for tokenIds: [String]) throws -> [IdentifiableResult<Any?>] {
         if let result = try proxyReaderContract?.callBatchMethod(methodName: GETDATA_METHOD_NAME, argsArray: tokenIds.map { [keys, $0] }) {
             return result }
         throw ResolutionError.proxyReaderNonInitialized

--- a/UnstoppableDomainsResolution.podspec
+++ b/UnstoppableDomainsResolution.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "UnstoppableDomainsResolution"
-  spec.version      = "0.1.3"
+  spec.version      = "0.1.4"
   spec.summary      = "Swift framework for resolving Unstoppable domains."
 
   spec.description  = <<-DESC


### PR DESCRIPTION
I modified the API of batchOwners() method -- in case the domain is not registered, the resulting array has `nil` in the relevant element, doesn't throw an error.