### PR TITLE
Refactor response to batch owner request

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,8 @@ let package = Package(
         .testTarget(
             name: "ResolutionTests",
             dependencies: ["UnstoppableDomainsResolution"],
-            exclude:["Info.plist"]
+            exclude:["Info.plist"],
+            swiftSettings: [.define("INSIDE_PM")]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ This framework helps to resolve a decentralized domain name such as `brad.crypto
 
 ## Cocoa Pods
 ```ruby
-pod 'UnstoppableDomainsResolution', '~> 0.1.3'
+pod 'UnstoppableDomainsResolution', '~> 0.1.4'
 ```
 ## Swift Package Manager
 ```swift
 package.dependencies.append(
-    .package(url: "https://github.com/unstoppabledomains/resolution-swift", from: "0.1.3")
+    .package(url: "https://github.com/unstoppabledomains/resolution-swift", from: "0.1.4")
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ package.dependencies.append(
  ```
  
  ## Batch request of owners
- In the version 0.1.3 there was introduced a method `batchOwners(domains: _, completion: _ )` that adds additional convenience to query the owners of the array of domains. The domains must be only CNS-compatible (other kind of domains will throw `ResolutionError.methodNotSupported`). As opposed to the single `owner(domain: _, completion: _)` method, this batch request will return the array of owners `[String?]`: if the the domain is not registered, the related array element of the response will be `nil` without throwing an error.
+ In the version 0.1.3 there was introduced a method `batchOwners(domains: _, completion: _ )` that adds additional convenience to query the owners of the array of domains. The domains must be only CNS-compatible (other kind of domains will throw `ResolutionError.methodNotSupported`). As opposed to the single `owner(domain: _, completion: _)` method, this batch request will return the array of owners `[String?]`: if the the domain is not registered (or its resolver is `null`, the related array element of the response will be `nil` without throwing an error.
  
  ```swift
  

--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ package.dependencies.append(
  ```
  
  ## Batch request of owners
- In the version 0.1.3 there was introduced a method `batchOwners(domains: _, completion: _ )` that adds additional convenience to query the owners of the array of domains. The domains must be only CNS-compatible (other kind of domains will throw `ResolutionError.methodNotSupported`). The result will return only if all domains are resolved.
+ In the version 0.1.3 there was introduced a method `batchOwners(domains: _, completion: _ )` that adds additional convenience to query the owners of the array of domains. The domains must be only CNS-compatible (other kind of domains will throw `ResolutionError.methodNotSupported`). As opposed to the single `owner(domain: _, completion: _)` method, this batch request will return the array of owners `[String?]`: if the the domain is not registered, the related array element of the response will be `nil` without throwing an error.
  
  ```swift
  
  resolution.batchOwners(domains: ["brad.crypto", "otherbrad.crypto"]) { result in
      switch result {
      case .success(let returnValue):
-           // returnValue = <array of owners's addresses>
+           // returnValue: [String?] = <array of owners's addresses>
          let domainOwner = returnValue
      case .failure(let error):
          XCTFail("Expected owner, but got \(error)")

--- a/Resolution.xcodeproj/project.pbxproj
+++ b/Resolution.xcodeproj/project.pbxproj
@@ -390,7 +390,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint autocorrect\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint autocorrect\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Resolution.xcodeproj/project.pbxproj
+++ b/Resolution.xcodeproj/project.pbxproj
@@ -259,6 +259,7 @@
 				84412BFF25029A0E0025EE78 /* Run swiftlint */,
 				3EE4DA0024E367720097540B /* Frameworks */,
 				3EE4DA0124E367720097540B /* Resources */,
+				30D54741253F006A00818D62 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -356,6 +357,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		30D54741253F006A00818D62 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
 		84412BFF25029A0E0025EE78 /* Run swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Sources/UnstoppableDomainsResolution/ABI/ABICoder.swift
+++ b/Sources/UnstoppableDomainsResolution/ABI/ABICoder.swift
@@ -11,6 +11,12 @@ import EthereumABI
 
 typealias ABIContract = [ABI.Element]
 
+enum ABICoderError: Error {
+    case wrongABIInterfaceForMethod(method: String)
+    case couldNotEncode(method: String, args: [Any])
+    case couldNotDecode(method: String, value: String)
+}
+
 // swiftlint:disable identifier_name cyclomatic_complexity
 internal class ABICoder {
     let abi: ABIContract
@@ -27,12 +33,6 @@ internal class ABICoder {
             }
         }
         return toReturn
-    }
-
-    enum ABICoderError: Error {
-        case wrongABIInterfaceForMethod(method: String)
-        case couldNotEncode(method: String, args: [Any])
-        case couldNotDecode(method: String, value: String)
     }
 
     init(_ abi: ABIContract) {

--- a/Sources/UnstoppableDomainsResolution/ABI/JSON_RPC.swift
+++ b/Sources/UnstoppableDomainsResolution/ABI/JSON_RPC.swift
@@ -12,22 +12,21 @@ import Foundation
 public struct JsonRpcPayload: Codable {
     let jsonrpc, id, method: String
     let params: [ParamElement]
-    
+
     enum CodingKeys: String, CodingKey {
         case jsonrpc
         case id
         case method
         case params
     }
-    
+
     init(jsonrpc: String, id: String, method: String, params: [ParamElement]) {
         self.jsonrpc = jsonrpc
         self.id = id
         self.method = method
         self.params = params
     }
-    
-    
+
     init (id: String, data: String, to address: String) {
         self.init(jsonrpc: "2.0",
                   id: id,
@@ -91,8 +90,14 @@ public struct ParamClass: Codable {
     let to: String
 }
 
-public struct JsonRpcResponse: Codable {
+public struct JsonRpcResponse: Decodable {
     let jsonrpc: String
     let id: String
     let result: ParamElement
+
+    enum CodingKeys: String, CodingKey {
+        case jsonrpc
+        case id
+        case result
+    }
 }

--- a/Sources/UnstoppableDomainsResolution/APIRequest.swift
+++ b/Sources/UnstoppableDomainsResolution/APIRequest.swift
@@ -43,7 +43,7 @@ struct APIRequest {
                                            completion: completion)
         } catch { throw APIError.encodingError }
     }
-    
+
     func post(_ bodyArray: [JsonRpcPayload], completion: @escaping(Result<JsonRpcResponseArray, APIError>) -> Void ) throws {
         do {
             networking.makeHttpPostRequest(url: self.url,
@@ -57,7 +57,7 @@ struct APIRequest {
 
 public struct DefaultNetworkingLayer: NetworkingLayer {
     public init() { }
-    
+
     public func makeHttpPostRequest(url: URL,
                                     httpMethod: String,
                                     httpHeaderContentType: String,
@@ -67,7 +67,7 @@ public struct DefaultNetworkingLayer: NetworkingLayer {
         urlRequest.httpMethod = httpMethod
         urlRequest.addValue(httpHeaderContentType, forHTTPHeaderField: "Content-Type")
         urlRequest.httpBody = httpBody
-        
+
         let dataTask = URLSession.shared.dataTask(with: urlRequest) { data, response, _ in
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200,
@@ -75,7 +75,7 @@ public struct DefaultNetworkingLayer: NetworkingLayer {
                 completion(.failure(.responseError))
                 return
             }
-            
+
             do {
                 let result = try JSONDecoder().decode(JsonRpcResponseArray.self, from: jsonData)
                 completion(.success(result))

--- a/Sources/UnstoppableDomainsResolution/APIRequest.swift
+++ b/Sources/UnstoppableDomainsResolution/APIRequest.swift
@@ -35,19 +35,23 @@ struct APIRequest {
     }
 
     func post(_ body: JsonRpcPayload, completion: @escaping(Result<JsonRpcResponseArray, APIError>) -> Void ) throws {
-        networking.makeHttpPostRequest(url: self.url,
-                                       httpMethod: "POST",
-                                       httpHeaderContentType: "application/json",
-                                       httpBody: try JSONEncoder().encode(body),
-                                       completion: completion)
+        do {
+            networking.makeHttpPostRequest(url: self.url,
+                                           httpMethod: "POST",
+                                           httpHeaderContentType: "application/json",
+                                           httpBody: try JSONEncoder().encode(body),
+                                           completion: completion)
+        } catch { throw APIError.encodingError }
     }
     
     func post(_ bodyArray: [JsonRpcPayload], completion: @escaping(Result<JsonRpcResponseArray, APIError>) -> Void ) throws {
-        networking.makeHttpPostRequest(url: self.url,
-                                       httpMethod: "POST",
-                                       httpHeaderContentType: "application/json",
-                                       httpBody: try JSONEncoder().encode(bodyArray),
-                                       completion: completion)
+        do {
+            networking.makeHttpPostRequest(url: self.url,
+                                           httpMethod: "POST",
+                                           httpHeaderContentType: "application/json",
+                                           httpBody: try JSONEncoder().encode(bodyArray),
+                                           completion: completion)
+        } catch { throw APIError.encodingError }
     }
 }
 

--- a/Sources/UnstoppableDomainsResolution/Contract.swift
+++ b/Sources/UnstoppableDomainsResolution/Contract.swift
@@ -13,11 +13,11 @@ struct IdentifiableResult<T> {
 
 import Foundation
 internal class Contract {
-    let BATCH_ID_OFFSET = 128
+    let batchIdOffset = 128
 
-    static let OWNER_KEY = "owner"
-    static let RESOLVER_KEY = "resolver"
-    static let VALUES_KEY = "values"
+    static let ownerKey = "owner"
+    static let resolverKey = "resolver"
+    static let valuesKey = "values"
 
     let address: String
     let providerUrl: String
@@ -41,7 +41,7 @@ internal class Contract {
     func callBatchMethod(methodName: String, argsArray: [[Any]]) throws -> [IdentifiableResult<Any?>] {
         let encodedDataArray = try argsArray.map { try self.coder.encode(method: methodName, args: $0) }
         let bodyArray: [JsonRpcPayload] = encodedDataArray.enumerated()
-                                                            .map { JsonRpcPayload(id: String($0.offset + BATCH_ID_OFFSET),
+                                                            .map { JsonRpcPayload(id: String($0.offset + batchIdOffset),
                                                                                   data: $0.element,
                                                                                   to: address) }
         let response = try postBatchRequest(bodyArray)

--- a/Sources/UnstoppableDomainsResolution/Contract.swift
+++ b/Sources/UnstoppableDomainsResolution/Contract.swift
@@ -14,7 +14,7 @@ struct IdentifiableResult<T> {
 import Foundation
 internal class Contract {
     let BATCH_ID_OFFSET = 128
-    
+
     static let OWNER_KEY = "owner"
     static let RESOLVER_KEY = "resolver"
     static let VALUES_KEY = "values"
@@ -37,7 +37,7 @@ internal class Contract {
         let response = try postRequest(body)!
         return try self.coder.decode(response, from: methodName)
     }
-    
+
     func callBatchMethod(methodName: String, argsArray: [[Any]]) throws -> [IdentifiableResult<Any?>] {
         let encodedDataArray = try argsArray.map { try self.coder.encode(method: methodName, args: $0) }
         let bodyArray: [JsonRpcPayload] = encodedDataArray.enumerated()
@@ -80,7 +80,7 @@ internal class Contract {
             return nil
         }
     }
-    
+
     private func postBatchRequest(_ bodyArray: [JsonRpcPayload]) throws -> [IdentifiableResult<String>?] {
         let postRequest = APIRequest(providerUrl, networking: networking)
         var resp: JsonRpcResponseArray?
@@ -99,11 +99,11 @@ internal class Contract {
         guard err == nil else {
             throw err!
         }
-        
+
         guard let responseArray = resp else { throw APIError.decodingError }
-        
+
         let parsedResponseArray: [IdentifiableResult<String>?] = responseArray.map {
-            if case let ParamElement.string ( stringResult ) = $0.result {
+            if case let ParamElement.string( stringResult ) = $0.result {
                 return IdentifiableResult<String>(id: $0.id, result: stringResult)
             }
             return nil

--- a/Sources/UnstoppableDomainsResolution/Helpers/Types.swift
+++ b/Sources/UnstoppableDomainsResolution/Helpers/Types.swift
@@ -11,4 +11,4 @@ import Foundation
 public typealias StringResultConsumer = (Result<String, ResolutionError>) -> Void
 public typealias StringsArrayResultConsumer = (Result<[String?], ResolutionError>) -> Void
 public typealias DictionaryResultConsumer = (Result<[String: String], ResolutionError>) -> Void
-public let EthCoinIndex = 60
+public let ethCoinIndex = 60

--- a/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
@@ -55,11 +55,11 @@ internal class CNS: CommonNamingService, NamingService {
     
     func batchOwners(domains: [String]) throws -> [String?] {
         let tokenIds = domains.map { super.namehash(domain: $0) }
-        let res: [IdentifiableResult<Any>]
+        let res: [IdentifiableResult<Any?>]
         do {
             res = try self.getBatchData(keys: [Contract.OWNER_KEY], for: tokenIds)
         } catch {
-            throw ResolutionError.unregisteredDomain
+            throw error
         }
         
         let rec = res.sorted(by: {Int($0.id)! < Int($1.id)!})
@@ -169,7 +169,7 @@ internal class CNS: CommonNamingService, NamingService {
         throw ResolutionError.proxyReaderNonInitialized
     }
     
-    private func getBatchData(keys: [String], for tokenIds: [String]) throws -> [IdentifiableResult<Any>] {
+    private func getBatchData(keys: [String], for tokenIds: [String]) throws -> [IdentifiableResult<Any?>] {
         if let result = try proxyReaderContract?.callBatchMethod(methodName: GETDATA_METHOD_NAME, argsArray: tokenIds.map { [keys, $0] }) {
             return result }
         throw ResolutionError.proxyReaderNonInitialized

--- a/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
@@ -17,7 +17,7 @@ internal class CNS: CommonNamingService, NamingService {
         "mainnet": "0xD1E5b0FF1287aA9f9A268759062E4Ab08b9Dacbe",
         "kovan": "0x22c2738cdA28C5598b1a68Fb1C89567c2364936F"
     ]
-    
+
     let GETDATA_METHOD_NAME = "getData"
 
     let network: String
@@ -52,7 +52,7 @@ internal class CNS: CommonNamingService, NamingService {
         }
         return rec
     }
-    
+
     func batchOwners(domains: [String]) throws -> [String?] {
         let tokenIds = domains.map { super.namehash(domain: $0) }
         let res: [IdentifiableResult<Any?>]
@@ -61,7 +61,7 @@ internal class CNS: CommonNamingService, NamingService {
         } catch {
             throw error
         }
-        
+
         let rec = res.sorted(by: {Int($0.id)! < Int($1.id)!})
             .map { self.unfold(contractResult: $0.result, key: Contract.OWNER_KEY) }
         return rec
@@ -168,7 +168,7 @@ internal class CNS: CommonNamingService, NamingService {
             return result }
         throw ResolutionError.proxyReaderNonInitialized
     }
-    
+
     private func getBatchData(keys: [String], for tokenIds: [String]) throws -> [IdentifiableResult<Any?>] {
         if let result = try proxyReaderContract?.callBatchMethod(methodName: GETDATA_METHOD_NAME, argsArray: tokenIds.map { [keys, $0] }) {
             return result }

--- a/Sources/UnstoppableDomainsResolution/NamingServices/CommonNamingService.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/CommonNamingService.swift
@@ -10,8 +10,8 @@ import Foundation
 import EthereumABI
 
 class CommonNamingService {
-    static let HEXADECIMAL_PREFIX = "0x"
-    static let JSON_EXTENSION = "json"
+    static let hexadecimalPrefix = "0x"
+    static let jsonExtension = "json"
 
     let name: String
     let providerUrl: String
@@ -73,7 +73,7 @@ class CommonNamingService {
                 .reversed()
                 .reduce(node) { return self.childHash(parent: $0, label: $1)}
         }
-        return "\(Self.HEXADECIMAL_PREFIX)\(node.toHexString())"
+        return "\(Self.hexadecimalPrefix)\(node.toHexString())"
     }
 
     func childHash(parent: [UInt8], label: [UInt8]) -> [UInt8] {

--- a/Sources/UnstoppableDomainsResolution/NamingServices/ENS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/ENS.swift
@@ -41,7 +41,7 @@ internal class ENS: CommonNamingService, NamingService {
         }
         return ownerAddress
     }
-    
+
     func batchOwners(domains: [String]) throws -> [String?] {
         throw ResolutionError.methodNotSupported
     }

--- a/Sources/UnstoppableDomainsResolution/NamingServices/ENS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/ENS.swift
@@ -55,7 +55,7 @@ internal class ENS: CommonNamingService, NamingService {
         let resolverAddress = try resolver(tokenId: tokenId)
         let resolverContract = try super.buildContract(address: resolverAddress, type: .resolver)
 
-        guard let dict = try resolverContract.callMethod(methodName: "addr", args: [tokenId, EthCoinIndex]) as? [String: Data],
+        guard let dict = try resolverContract.callMethod(methodName: "addr", args: [tokenId, ethCoinIndex]) as? [String: Data],
               let dataAddress = dict["0"],
               let address = EthereumAddress(dataAddress),
               Utillities.isNotEmpty(address.address) else {

--- a/Sources/UnstoppableDomainsResolution/NamingServices/ZNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/ZNS.swift
@@ -38,7 +38,7 @@ internal class ZNS: CommonNamingService, NamingService {
 
         return ownerAddress
     }
-    
+
     func batchOwners(domains: [String]) throws -> [String?] {
         throw ResolutionError.methodNotSupported
     }

--- a/Sources/UnstoppableDomainsResolution/Protocols/NamingService.swift
+++ b/Sources/UnstoppableDomainsResolution/Protocols/NamingService.swift
@@ -19,7 +19,7 @@ protocol NamingService {
     func owner(domain: String) throws -> String
     func addr(domain: String, ticker: String) throws -> String
     func resolver(domain: String) throws -> String
-    
+
     func batchOwners(domains: [String]) throws -> [String?]
 
     func record(domain: String, key: String) throws -> String

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -42,7 +42,7 @@ public class Resolution {
 
     private var providerUrl: String
     private let services: [NamingService]
-    
+
     public init(providerUrl: String = "https://main-rpc.linkpool.io",
                 network: String = "mainnet",
                 networking: NetworkingLayer = DefaultNetworkingLayer() ) throws {
@@ -113,7 +113,7 @@ public class Resolution {
             }
         }
     }
-    
+
     /// Resolves give `domain` name to a specific `currency address` if exists
     /// - Parameter  domain: - domain name to be resolved
     /// - Parameter  ticker: - currency ticker like BTC, ETH, ZIL
@@ -268,7 +268,7 @@ public class Resolution {
         }
         return service
     }
-    
+
     /// This returns the correct naming service based on the `domain`'s array asked for
     private func getServiceOf(domains: [String]) throws -> NamingService {
         guard domains.count > 0 else {
@@ -281,7 +281,7 @@ public class Resolution {
         guard possibleServices.count == domains.count else {
             throw ResolutionError.unsupportedDomain
         }
-        
+
         let service: NamingService? = try possibleServices.reduce(nil, {result, currNS in
             guard result != nil else { return currNS }
             guard result!.name == currNS.name else { throw ResolutionError.inconsistenDomainArray }
@@ -312,7 +312,7 @@ public class Resolution {
         }
         completion(.failure(catched))
     }
-    
+
     /// Process the 'error'
     private func catchError(_ error: Error, completion:@escaping StringsArrayResultConsumer ) {
         guard let catched = error as? ResolutionError else {

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -98,7 +98,8 @@ public class Resolution {
     }
 
     /// Resolves owner addresses of an array of `domain`s
-    /// - Parameter domains: - array of domain names
+    /// - Parameter domains: - array of domain names, with nil value if the domain is not registered or
+    ///     its resolver is null
     /// - Parameter completion: A callback that resolves `Result`  with an array of `owner address`'s or `Error`
     public func batchOwners(domains: [String], completion: @escaping StringsArrayResultConsumer ) {
         let preparedDomains = domains.map { prepare(domain: $0) }

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -202,7 +202,8 @@ public class Resolution {
         let preparedDomain = prepare(domain: domain)
         DispatchQueue.global(qos: .utility).async { [weak self] in
             do {
-                if let result = try self?.getServiceOf(domain: preparedDomain).record(domain: preparedDomain, key: "gundb.public_key.value") {
+                if let result = try self?.getServiceOf(domain: preparedDomain)
+                    .record(domain: preparedDomain, key: "gundb.public_key.value") {
                     completion(.success(result))
                 }
             } catch {
@@ -218,7 +219,8 @@ public class Resolution {
         let preparedDomain = prepare(domain: domain)
         DispatchQueue.global(qos: .utility).async { [weak self] in
             do {
-                if let result = try self?.getServiceOf(domain: preparedDomain).record(domain: preparedDomain, key: "ipfs.redirect_domain.value") {
+                if let result = try self?.getServiceOf(domain: preparedDomain)
+                    .record(domain: preparedDomain, key: "ipfs.redirect_domain.value") {
                     completion(.success(result))
                 }
             } catch {

--- a/UnstoppableDomainsResolution.podspec
+++ b/UnstoppableDomainsResolution.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "UnstoppableDomainsResolution"
-  spec.version      = "0.1.3"
+  spec.version      = "0.1.4"
   spec.summary      = "Swift framework for resolving Unstoppable domains."
 
   spec.description  = <<-DESC


### PR DESCRIPTION
Batch request brings `nil` element in the response array if the domain is not registered OR its resolver is `null`