### PR TITLE
BadRequestOrResponse is Handled

### DIFF
--- a/Sources/UnstoppableDomainsResolution/Contract.swift
+++ b/Sources/UnstoppableDomainsResolution/Contract.swift
@@ -7,6 +7,7 @@
 //
 
 struct IdentifiableResult<T> {
+    // swiftlint:disable:next identifier_name
     var id: String
     var result: T
 }

--- a/Sources/UnstoppableDomainsResolution/Errors.swift
+++ b/Sources/UnstoppableDomainsResolution/Errors.swift
@@ -19,4 +19,32 @@ public enum ResolutionError: Error {
     case proxyReaderNonInitialized
     case inconsistenDomainArray
     case methodNotSupported
+    case tooManyResponses
+    case badRequestOrResponse
+
+    static let tooManyResponsesCode = -32005
+    static let badRequestOrResponseCode = -32042
+
+    static func parse (errorResponse: NetworkErrorResponse) -> ResolutionError? {
+        let error = errorResponse.error
+        if error.code == tooManyResponsesCode {
+            return .tooManyResponses
+        }
+        if error.code == badRequestOrResponseCode {
+            return .badRequestOrResponse
+        }
+        return nil
+    }
+}
+
+struct NetworkErrorResponse: Decodable {
+    var jsonrpc: String
+    // swiftlint:disable:next identifier_name
+    var id: String
+    var error: ErrorId
+}
+
+struct ErrorId: Codable {
+    var code: Int
+    var message: String
 }

--- a/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
@@ -106,8 +106,10 @@ internal class CNS: CommonNamingService, NamingService {
         var result: (owner: String, resolver: String, record: String) = ("", "", "")
         do {
             result = try self.getOwnerResolverRecord(tokenId: tokenId, key: key)
-        } catch {
+        } catch { if error is ABICoderError {
             throw ResolutionError.unspecifiedResolver
+        }
+        throw error
         }
         guard Utillities.isNotEmpty(result.owner) else { throw ResolutionError.unregisteredDomain }
         guard Utillities.isNotEmpty(result.resolver) else { throw ResolutionError.unspecifiedResolver }

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -430,18 +430,25 @@ extension ResolutionError: Equatable {
             return true
         case (.methodNotSupported, .methodNotSupported):
             return true
+        case (.tooManyResponses, .tooManyResponses):
+            return true
+        case (.badRequestOrResponse, .badRequestOrResponse):
+            return true
+            
         // We don't use `default` here on purpose, so we don't forget updating this method on adding new variants.
         case (.unregisteredDomain, _),
-            (.unsupportedDomain, _),
-            (.recordNotFound, _),
-            (.recordNotSupported, _),
-            (.unsupportedNetwork, _),
-            (.unspecifiedResolver, _),
-            (.unknownError, _ ),
-            (.inconsistenDomainArray, _),
-            (.methodNotSupported, _),
-            (.proxyReaderNonInitialized, _):
-
+             (.unsupportedDomain, _),
+             (.recordNotFound, _),
+             (.recordNotSupported, _),
+             (.unsupportedNetwork, _),
+             (.unspecifiedResolver, _),
+             (.unknownError, _ ),
+             (.inconsistenDomainArray, _),
+             (.methodNotSupported, _),
+             (.proxyReaderNonInitialized, _),
+             (.tooManyResponses, _),
+             (.badRequestOrResponse, _):
+            
             return false
         }
     }


### PR DESCRIPTION
`BadRequestOrResponse` error used to be mistakingly reported as `UnspecifiedResolver`. Fixed