### PR TITLE
Dns records support

### DIFF
--- a/Resolution.xcodeproj/project.pbxproj
+++ b/Resolution.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		30A69245251385A70079EC69 /* cnsProxyReader.json in Resources */ = {isa = PBXBuildFile; fileRef = 30A69244251385A70079EC69 /* cnsProxyReader.json */; };
 		30AE8615257A8CCD003A0142 /* network-config.json in Resources */ = {isa = PBXBuildFile; fileRef = 30AE8614257A8CCD003A0142 /* network-config.json */; };
+		3E105520258C95D300652FC7 /* DnsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E10551F258C95D300652FC7 /* DnsType.swift */; };
+		3E105524258CB73400652FC7 /* DnsUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E105523258CB73400652FC7 /* DnsUtils.swift */; };
+		3E10552E258CBD0900652FC7 /* DnsRecordsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E10552D258CBD0900652FC7 /* DnsRecordsError.swift */; };
 		3E2AC91C24E4FA28008EBC39 /* CNS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2AC91B24E4FA28008EBC39 /* CNS.swift */; };
 		3E2AC91F24E4FA35008EBC39 /* NamingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2AC91E24E4FA35008EBC39 /* NamingService.swift */; };
 		3E2AC93E24E4FC9F008EBC39 /* cnsResolver.json in Resources */ = {isa = PBXBuildFile; fileRef = 3E2AC93C24E4FC9F008EBC39 /* cnsResolver.json */; };
@@ -48,6 +51,9 @@
 		3045D148251E2C6200B65A06 /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
 		30A69244251385A70079EC69 /* cnsProxyReader.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = cnsProxyReader.json; sourceTree = "<group>"; };
 		30AE8614257A8CCD003A0142 /* network-config.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "network-config.json"; sourceTree = "<group>"; };
+		3E10551F258C95D300652FC7 /* DnsType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DnsType.swift; sourceTree = "<group>"; };
+		3E105523258CB73400652FC7 /* DnsUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DnsUtils.swift; sourceTree = "<group>"; };
+		3E10552D258CBD0900652FC7 /* DnsRecordsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DnsRecordsError.swift; sourceTree = "<group>"; };
 		3E2AC91B24E4FA28008EBC39 /* CNS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CNS.swift; sourceTree = "<group>"; };
 		3E2AC91E24E4FA35008EBC39 /* NamingService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NamingService.swift; sourceTree = "<group>"; };
 		3E2AC93C24E4FC9F008EBC39 /* cnsResolver.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = cnsResolver.json; sourceTree = "<group>"; };
@@ -105,6 +111,16 @@
 				8449EDF825139F2500DABB57 /* ENS */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		3E10551E258C95BD00652FC7 /* DNS */ = {
+			isa = PBXGroup;
+			children = (
+				3E10551F258C95D300652FC7 /* DnsType.swift */,
+				3E105523258CB73400652FC7 /* DnsUtils.swift */,
+				3E10552D258CBD0900652FC7 /* DnsRecordsError.swift */,
+			);
+			path = DNS;
 			sourceTree = "<group>";
 		};
 		3E2AC91A24E4FA28008EBC39 /* NamingServices */ = {
@@ -217,6 +233,7 @@
 		848E210A25079D43008707D2 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				3E10551E258C95BD00652FC7 /* DNS */,
 				3EAFA40124EE312A008791E9 /* Utilities.swift */,
 				848E210B25079D61008707D2 /* Types.swift */,
 			);
@@ -314,7 +331,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 3EE4D9FD24E367720097540B /* Build configuration list for PBXProject "Resolution" */;
+			buildConfigurationList = 3EE4D9FD24E367720097540B /* Build configuration list for PBXProject "resolution" */;
 			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -410,6 +427,7 @@
 				848E21092507890A008707D2 /* ZNS.swift in Sources */,
 				3E65912824E381E900D7EC35 /* Errors.swift in Sources */,
 				3EAFA3F724EB59DA008791E9 /* ABICoder.swift in Sources */,
+				3E105520258C95D300652FC7 /* DnsType.swift in Sources */,
 				3EE4DA1E24E367D40097540B /* Resolution.swift in Sources */,
 				848E210C25079D61008707D2 /* Types.swift in Sources */,
 				3E65913124E4ADAC00D7EC35 /* Contract.swift in Sources */,
@@ -417,6 +435,8 @@
 				3EAFA40224EE312A008791E9 /* Utilities.swift in Sources */,
 				3EAFA3FE24EE03E0008791E9 /* JSON_RPC.swift in Sources */,
 				8402F708250935FE0007F01D /* ContractZNS.swift in Sources */,
+				3E105524258CB73400652FC7 /* DnsUtils.swift in Sources */,
+				3E10552E258CBD0900652FC7 /* DnsRecordsError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -655,7 +675,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		3EE4D9FD24E367720097540B /* Build configuration list for PBXProject "Resolution" */ = {
+		3EE4D9FD24E367720097540B /* Build configuration list for PBXProject "resolution" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				3EE4DA1524E367720097540B /* Debug */,

--- a/Sources/UnstoppableDomainsResolution/APIRequest.swift
+++ b/Sources/UnstoppableDomainsResolution/APIRequest.swift
@@ -83,6 +83,11 @@ public struct DefaultNetworkingLayer: NetworkingLayer {
                     let result = try JSONDecoder().decode(JsonRpcResponse.self, from: jsonData)
                     completion(.success([result]))
                 } catch {
+                    if let JSONString = String(data: jsonData, encoding: String.Encoding.utf8) {
+                       print(JSONString)
+                    }
+                    print(jsonData)
+                    print(String(data: jsonData, encoding: String.Encoding.utf8))
                     if let errorResponse = try? JSONDecoder().decode(NetworkErrorResponse.self, from: jsonData),
                        let errorExplained = ResolutionError.parse(errorResponse: errorResponse) {
                         completion(.failure(errorExplained))

--- a/Sources/UnstoppableDomainsResolution/APIRequest.swift
+++ b/Sources/UnstoppableDomainsResolution/APIRequest.swift
@@ -83,11 +83,6 @@ public struct DefaultNetworkingLayer: NetworkingLayer {
                     let result = try JSONDecoder().decode(JsonRpcResponse.self, from: jsonData)
                     completion(.success([result]))
                 } catch {
-                    if let JSONString = String(data: jsonData, encoding: String.Encoding.utf8) {
-                       print(JSONString)
-                    }
-                    print(jsonData)
-                    print(String(data: jsonData, encoding: String.Encoding.utf8))
                     if let errorResponse = try? JSONDecoder().decode(NetworkErrorResponse.self, from: jsonData),
                        let errorExplained = ResolutionError.parse(errorResponse: errorResponse) {
                         completion(.failure(errorExplained))

--- a/Sources/UnstoppableDomainsResolution/Helpers/DNS/DnsRecordsError.swift
+++ b/Sources/UnstoppableDomainsResolution/Helpers/DNS/DnsRecordsError.swift
@@ -10,4 +10,5 @@ import Foundation
 
 public enum DnsRecordsError: Error {
     case dnsRecordCorrupted(recordType: DnsType)
+    case inconsistentTtl(recordType: DnsType)
 }

--- a/Sources/UnstoppableDomainsResolution/Helpers/DNS/DnsRecordsError.swift
+++ b/Sources/UnstoppableDomainsResolution/Helpers/DNS/DnsRecordsError.swift
@@ -1,0 +1,13 @@
+//
+//  DnsRecordsError.swift
+//  UnstoppableDomainsResolution
+//
+//  Created by Johnny Good on 12/18/20.
+//  Copyright © 2020 Unstoppable Domains. All rights reserved.
+//
+
+import Foundation
+
+public enum DnsRecordsError: Error {
+    case dnsRecordCorrupted(recordType: DnsType)
+}

--- a/Sources/UnstoppableDomainsResolution/Helpers/DNS/DnsType.swift
+++ b/Sources/UnstoppableDomainsResolution/Helpers/DNS/DnsType.swift
@@ -1,0 +1,81 @@
+//
+//  DnsType.swift
+//  UnstoppableDomainsResolution
+//
+//  Created by Johnny Good on 12/17/20.
+//  Copyright © 2020 Unstoppable Domains. All rights reserved.
+//
+// swiftlint:disable identifier_name
+
+import Foundation
+
+public enum DnsType: String {
+    case A
+    case AAAA
+    case AFSDB
+    case APL
+    case CAA
+    case CDNSKEY
+    case CDS
+    case CERT
+    case CNAME
+    case CSYNC
+    case DHCID
+    case DLV
+    case DNAME
+    case DNSKEY
+    case DS
+    case EUI48
+    case EUI64
+    case HINFO
+    case HIP
+    case HTTPS
+    case IPSECKEY
+    case KEY
+    case KX
+    case LOC
+    case MX
+    case NAPTR
+    case NS
+    case NSEC
+    case NSEC3
+    case NSEC3PARAM
+    case OPENPGPKEY
+    case PTR
+    case RP
+    case RRSIG
+    case SIG
+    case SMIMEA
+    case SOA
+    case SRV
+    case SSHFP
+    case SVCB
+    case TA
+    case TKEY
+    case TLSA
+    case TSIG
+    case TXT
+    case URI
+    case ZONEMD
+
+    static func getCryptoRecords(types: [DnsType], ttl: Bool) -> [String] {
+        var cryptoRecords: [String] = []
+        if ttl {
+            cryptoRecords.append("dns.ttl")
+        }
+        for type in types {
+            if ttl {
+                cryptoRecords.append(self.getCryptoRecord(type: type, with: ttl))
+            }
+            cryptoRecords.append(self.getCryptoRecord(type: type))
+        }
+        return cryptoRecords
+    }
+
+    static func getCryptoRecord(type: DnsType, with ttl: Bool = false) -> String {
+        if ttl {
+            return "dns.\(type).ttl"
+        }
+        return "dns.\(type)"
+    }
+}

--- a/Sources/UnstoppableDomainsResolution/Helpers/DNS/DnsUtils.swift
+++ b/Sources/UnstoppableDomainsResolution/Helpers/DNS/DnsUtils.swift
@@ -1,0 +1,77 @@
+//
+//  DnsUtils.swift
+//  UnstoppableDomainsResolution
+//
+//  Created by Johnny Good on 12/18/20.
+//  Copyright © 2020 Unstoppable Domains. All rights reserved.
+//
+
+import Foundation
+
+public struct DnsRecord: Equatable {
+    var ttl: Int
+    var type: String
+    var data: String
+
+    static public func == (lhs: DnsRecord, rhs: DnsRecord) -> Bool {
+        return lhs.ttl == rhs.ttl && lhs.type == rhs.type && lhs.data == rhs.data
+    }
+}
+
+public class DnsUtils {
+    init() {}
+
+    static let DefaultTtl: Int = 300
+
+    public func toList(map: [String: String]) throws -> [DnsRecord] {
+        let dnsTypes = self.getAllDnsTypes(map: map)
+        var recordList: [DnsRecord] = []
+        for type in dnsTypes {
+            recordList += try self.constructDnsRecord(map: map, type: type)
+        }
+        return recordList
+    }
+
+    private func constructDnsRecord(map: [String: String], type: DnsType) throws -> [DnsRecord] {
+        var dnsRecords: [DnsRecord] = []
+        let ttl: Int = self.parseTtl(map: map, type: type)
+        guard let jsonValueString: String = map["dns.\(type)"] else {
+            return []
+        }
+        do {
+            let data = Data(jsonValueString.utf8)
+            // swiftlint:disable force_cast
+            let recordDataArray = try JSONSerialization.jsonObject(with: data) as! [String]
+            // swiftlint:enable force_cast
+            for record in recordDataArray {
+                dnsRecords.append(DnsRecord(ttl: ttl, type: "\(type)", data: record))
+            }
+            return dnsRecords
+        } catch {
+            throw DnsRecordsError.dnsRecordCorrupted(recordType: type)
+        }
+    }
+
+    private func getAllDnsTypes(map: [String: String]) -> [DnsType] {
+        var types: Set<DnsType> = []
+        for (key, _) in map {
+            let chunks: [String] = key.components(separatedBy: ".")
+            if chunks.count >= 1 && chunks[1] != "ttl" {
+                if let type = DnsType(rawValue: chunks[1]) {
+                    types.insert(type)
+                }
+            }
+        }
+        return Array(types)
+    }
+
+    private func parseTtl(map: [String: String], type: DnsType) -> Int {
+        if let recordTtl = Int(map["dns.\(type).ttl"]!) {
+            return recordTtl
+        }
+        if let defaultRecordTtl = Int(map["dns.ttl"]!) {
+            return defaultRecordTtl
+        }
+        return DnsUtils.DefaultTtl
+    }
+}

--- a/Sources/UnstoppableDomainsResolution/Helpers/Types.swift
+++ b/Sources/UnstoppableDomainsResolution/Helpers/Types.swift
@@ -11,4 +11,5 @@ import Foundation
 public typealias StringResultConsumer = (Result<String, ResolutionError>) -> Void
 public typealias StringsArrayResultConsumer = (Result<[String?], ResolutionError>) -> Void
 public typealias DictionaryResultConsumer = (Result<[String: String], ResolutionError>) -> Void
+public typealias DnsRecordsResultConsumer = (Result<[DnsRecord], Error>) -> Void
 public let ethCoinIndex = 60

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -228,6 +228,25 @@ public class Resolution {
             }
         }
     }
+    /// Resolves dns record of a `domain`
+    /// - Parameter domain: - domain name to be resolved
+    /// - Parameter type: - dns record type
+    public func dns(domain: String, types: [DnsType], completion:@escaping DnsRecordsResultConsumer) {
+        let preparedDomain = prepare(domain: domain)
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            do {
+                let cryptoRecords = DnsType.getCryptoRecords(types: types, ttl: true)
+                if let result = try self?.getServiceOf(domain: preparedDomain)
+                    .records(keys: cryptoRecords, for: preparedDomain) {
+                    let utils = DnsUtils.init()
+                    let parsed = try utils.toList(map: result)
+                    completion(.success(parsed))
+                }
+            } catch {
+                self?.catchError(error, completion: completion)
+            }
+        }
+    }
 
     /// Resolves custom record of a `domain`
     /// - Parameter  domain: - domain name to be resolved
@@ -319,6 +338,18 @@ public class Resolution {
     private func catchError(_ error: Error, completion:@escaping StringsArrayResultConsumer ) {
         guard let catched = error as? ResolutionError else {
             completion(.failure(.unknownError(error)))
+            return
+        }
+        completion(.failure(catched))
+    }
+
+    private func catchError(_ error: Error, completion:@escaping DnsRecordsResultConsumer) {
+        guard let catched = error as? ResolutionError else {
+            guard let catched = error as? DnsRecordsError else {
+                completion(.failure(ResolutionError.unknownError(error)))
+                return
+            }
+            completion(.failure(catched))
             return
         }
         completion(.failure(catched))

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -245,7 +245,6 @@ public class Resolution {
 
                 let parsed = try DnsUtils.init().toList(map: result)
                 completion(.success(parsed))
-
             } catch {
                 self?.catchError(error, completion: completion)
             }

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -53,6 +53,33 @@ class ResolutionTests: XCTestCase {
         assert(zilHashTest == "0xd7587a5c8caad4941c598440d34f3a454e79889c48e510d13c7c5d1dfc6eab45")
         assert(ethHashTest == "0x2b53e3f567989ee41b897998d89eb4d8cf0715fb2cfb41a64939a532c09e495e")
     }
+    
+    func testDns() throws {
+        
+        // Given
+        let domain: String = "udtestdev-reseller-test-udtesting-875948372642.crypto";
+        let domainDnsReceived = expectation(description: "Dns record should be received")
+        let dnsTypes: [DnsType] = [.A, .AAAA];
+        
+        var testResult: [DnsRecord] = []
+        
+        //When
+        resolution.dns(domain: domain, types: dnsTypes) { (result) in
+            switch result {
+            case .success(let returnValue):
+                domainDnsReceived.fulfill();
+                testResult = returnValue;
+            case .failure(let error):
+                XCTFail("Expected dns record, but got \(error)")
+            }
+        }
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        assert(testResult[0] == DnsRecord(ttl: 98, type: "A", data: "10.0.0.1"));
+        assert(testResult[1] == DnsRecord(ttl: 98, type: "A", data: "10.0.0.3"));
+        
+    }
 
     func testGetOwner() throws {
 

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -81,7 +81,6 @@ class ResolutionTests: XCTestCase {
         
         let utils = DnsUtils.init();
         let backConversion = try utils.toMap(records: testResult);
-        print(backConversion);
         assert(backConversion["dns.A.ttl"] == "98");
         assert(backConversion["dns.A"] == """
         ["10.0.0.1","10.0.0.3"]
@@ -396,7 +395,6 @@ class ResolutionTests: XCTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        print(values)
         assert(values["ipfs.html.value"] == "Qme54oEzRkgooJbCDr78vzKAWcv6DDEZqRhhDyDtzgrZP6")
         assert(values["crypto.BTC.address"] == "bc1q359khn0phg58xgezyqsuuaha28zkwx047c0c3y")
         assert(values["crypto.ETH.address"] == "0x8aaD44321A86b170879d7A244c1e8d360c99DdA8")

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -79,6 +79,14 @@ class ResolutionTests: XCTestCase {
         assert(testResult[0] == DnsRecord(ttl: 98, type: "A", data: "10.0.0.1"));
         assert(testResult[1] == DnsRecord(ttl: 98, type: "A", data: "10.0.0.3"));
         
+        let utils = DnsUtils.init();
+        let backConversion = try utils.toMap(records: testResult);
+        print(backConversion);
+        assert(backConversion["dns.A.ttl"] == "98");
+        assert(backConversion["dns.A"] == """
+        ["10.0.0.1","10.0.0.3"]
+        """);
+        
     }
 
     func testGetOwner() throws {


### PR DESCRIPTION
This PR implements basic DnsRecord resolution support similar to [resolution.js](https://github.com/unstoppabledomains/resolution/pull/99) and [resolution-java](https://github.com/unstoppabledomains/resolution-java/pull/26)

Allows end-user to resolve various DNS records from .crypto domain.
Introduces DnsUtils class with 2 public functions: ToList and ToMap. This is a helper class to parse and work with records in a more easier and standardized way. 
