### PR TITLE
Auto network

### DIFF
--- a/Sources/UnstoppableDomainsResolution/ABI/EthereumABI/ABIElements.swift
+++ b/Sources/UnstoppableDomainsResolution/ABI/EthereumABI/ABIElements.swift
@@ -37,7 +37,7 @@ public extension ABI {
     }
 
     enum Element {
-        public enum ArraySize { //bytes for convenience
+        public enum ArraySize { // bytes for convenience
             case staticSize(UInt64)
             case dynamicSize
             case notArray

--- a/Sources/UnstoppableDomainsResolution/Configurations.swift
+++ b/Sources/UnstoppableDomainsResolution/Configurations.swift
@@ -15,7 +15,7 @@ public struct NamingServiceConfig {
 
     public init(
         providerUrl: String,
-        network: String = "mainnet",
+        network: String = "",
         networking: NetworkingLayer = DefaultNetworkingLayer()
     ) {
         self.network = network
@@ -30,9 +30,15 @@ public struct Configurations {
     let ens: NamingServiceConfig
 
     public init(
-        cns: NamingServiceConfig = NamingServiceConfig(providerUrl: "https://mainnet.infura.io/v3/3c25f57353234b1b853e9861050f4817"),
-        ens: NamingServiceConfig = NamingServiceConfig(providerUrl: "https://mainnet.infura.io/v3/d423cf2499584d7fbe171e33b42cfbee"),
-        zns: NamingServiceConfig = NamingServiceConfig(providerUrl: "https://api.zilliqa.com/")
+        cns: NamingServiceConfig = NamingServiceConfig(
+            providerUrl: "https://mainnet.infura.io/v3/3c25f57353234b1b853e9861050f4817",
+            network: "mainnet"),
+        ens: NamingServiceConfig = NamingServiceConfig(
+            providerUrl: "https://mainnet.infura.io/v3/d423cf2499584d7fbe171e33b42cfbee",
+            network: "mainnet"),
+        zns: NamingServiceConfig = NamingServiceConfig(
+            providerUrl: "https://api.zilliqa.com",
+            network: "mainnet")
     ) {
         self.ens = ens
         self.cns = cns

--- a/Sources/UnstoppableDomainsResolution/Errors.swift
+++ b/Sources/UnstoppableDomainsResolution/Errors.swift
@@ -21,6 +21,7 @@ public enum ResolutionError: Error {
     case methodNotSupported
     case tooManyResponses
     case badRequestOrResponse
+    case unsupportedServiceName
 
     static let tooManyResponsesCode = -32005
     static let badRequestOrResponseCode = -32042

--- a/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
@@ -26,8 +26,12 @@ internal class CNS: CommonNamingService, NamingService {
     var proxyReaderContract: Contract?
 
     init(_ config: NamingServiceConfig) throws {
-        self.network = config.network
 
+        if config.network.isEmpty {
+            self.network = try Self.getNetworkId(providerUrl: config.providerUrl, networking: config.networking)!
+        } else {
+            self.network = config.network
+        }
         guard let contractsContainer = try Self.parseContractAddresses(network: network),
               let registry = contractsContainer[ContractType.registry.name]?.address,
               let resolver = contractsContainer[ContractType.resolver.name]?.address,

--- a/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
@@ -27,11 +27,10 @@ internal class CNS: CommonNamingService, NamingService {
 
     init(_ config: NamingServiceConfig) throws {
 
-        if config.network.isEmpty {
-            self.network = try Self.getNetworkId(providerUrl: config.providerUrl, networking: config.networking)
-        } else {
-            self.network = config.network
-        }
+        self.network = config.network.isEmpty
+            ? try Self.getNetworkId(providerUrl: config.providerUrl, networking: config.networking)
+            : config.network
+
         guard let contractsContainer = try Self.parseContractAddresses(network: network),
               let registry = contractsContainer[ContractType.registry.name]?.address,
               let resolver = contractsContainer[ContractType.resolver.name]?.address,

--- a/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
@@ -28,7 +28,7 @@ internal class CNS: CommonNamingService, NamingService {
     init(_ config: NamingServiceConfig) throws {
 
         if config.network.isEmpty {
-            self.network = try Self.getNetworkId(providerUrl: config.providerUrl, networking: config.networking)!
+            self.network = try Self.getNetworkId(providerUrl: config.providerUrl, networking: config.networking)
         } else {
             self.network = config.network
         }

--- a/Sources/UnstoppableDomainsResolution/NamingServices/CommonNamingService.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/CommonNamingService.swift
@@ -126,7 +126,7 @@ extension CommonNamingService {
         return nil
     }
 
-    static func getNetworkId(providerUrl: String, networking: NetworkingLayer) throws -> String? {
+    static func getNetworkId(providerUrl: String, networking: NetworkingLayer) throws -> String {
         let url = URL(string: providerUrl)!
         let payload: JsonRpcPayload = JsonRpcPayload(jsonrpc: "2.0", id: "67", method: "net_version", params: [])
 
@@ -154,9 +154,9 @@ extension CommonNamingService {
         }
         switch resp?[0].result {
         case .string(let result):
-            return networkIds.key(forValue: result)
+            return networkIds.key(forValue: result) ?? ""
         default:
-            return nil
+            return ""
         }
     }
 }

--- a/Sources/UnstoppableDomainsResolution/NamingServices/CommonNamingService.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/CommonNamingService.swift
@@ -88,7 +88,9 @@ class CommonNamingService {
 extension CommonNamingService {
     static let networkConfigFileName = "network-config"
     static let networkIds = ["mainnet": "1",
-                             "rinkeby": "4"]
+                             "ropsten": "3",
+                             "rinkeby": "4",
+                             "goerli": "5"]
 
     struct NewtorkConfigJson: Decodable {
         let version: String
@@ -122,5 +124,45 @@ extension CommonNamingService {
             return currentNetwork.contracts
         }
         return nil
+    }
+
+    static func getNetworkId(providerUrl: String, networking: NetworkingLayer) throws -> String? {
+        let url = URL(string: providerUrl)!
+        let payload: JsonRpcPayload = JsonRpcPayload(jsonrpc: "2.0", id: "67", method: "net_version", params: [])
+
+        var resp: JsonRpcResponseArray?
+        var err: Error?
+        let semaphore = DispatchSemaphore(value: 0)
+
+        networking.makeHttpPostRequest(
+            url: url,
+            httpMethod: "POST",
+            httpHeaderContentType: "application/json",
+            httpBody: try JSONEncoder().encode(payload)
+        ) { result in
+            switch result {
+            case .success(let response):
+                resp = response
+            case .failure(let error):
+                err = error
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        guard err == nil else {
+            throw err!
+        }
+        switch resp?[0].result {
+        case .string(let result):
+            return networkIds.key(forValue: result)
+        default:
+            return nil
+        }
+    }
+}
+
+fileprivate extension Dictionary where Value: Equatable {
+    func key(forValue value: Value) -> Key? {
+        return first { $0.1 == value }?.0
     }
 }

--- a/Sources/UnstoppableDomainsResolution/NamingServices/ENS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/ENS.swift
@@ -23,7 +23,7 @@ internal class ENS: CommonNamingService, NamingService {
     init(_ config: NamingServiceConfig) throws {
 
         self.network = config.network.isEmpty
-            ? try Self.getNetworkId(providerUrl: config.providerUrl, networking: config.networking)!
+            ? try Self.getNetworkId(providerUrl: config.providerUrl, networking: config.networking)
             : config.network
 
         guard let registryAddress = registryMap[self.network] else {

--- a/Sources/UnstoppableDomainsResolution/NamingServices/ENS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/ENS.swift
@@ -21,10 +21,14 @@ internal class ENS: CommonNamingService, NamingService {
     ]
 
     init(_ config: NamingServiceConfig) throws {
-        guard let registryAddress = registryMap[config.network] else {
+
+        self.network = config.network.isEmpty
+            ? try Self.getNetworkId(providerUrl: config.providerUrl, networking: config.networking)!
+            : config.network
+
+        guard let registryAddress = registryMap[self.network] else {
             throw ResolutionError.unsupportedNetwork
         }
-        self.network = config.network
         self.registryAddress = registryAddress
         super.init(name: "ENS", providerUrl: config.providerUrl, networking: config.networking)
     }

--- a/Sources/UnstoppableDomainsResolution/NamingServices/ZNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/ZNS.swift
@@ -17,12 +17,26 @@ internal class ZNS: CommonNamingService, NamingService {
     ]
 
     init(_ config: NamingServiceConfig) throws {
-        guard let registryAddress = registryMap[config.network] else {
+
+        self.network = config.network.isEmpty
+            ? Self.getNetworkFromUrl(config.providerUrl)
+            : config.network
+
+        guard let registryAddress = registryMap[self.network] else {
             throw ResolutionError.unsupportedNetwork
         }
-        self.network = config.network
+
         self.registryAddress = registryAddress
         super.init(name: "ZNS", providerUrl: config.providerUrl, networking: config.networking)
+    }
+
+    static func getNetworkFromUrl(_ url: String) -> String {
+        if url.contains("dev-zilliqa") {
+            return "testnet"
+        } else if url.contains("api.zilliqa") {
+            return "mainnet"
+        }
+        return ""
     }
 
     func isSupported(domain: String) -> Bool {

--- a/Sources/UnstoppableDomainsResolution/NamingServices/ZNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/ZNS.swift
@@ -16,10 +16,14 @@ internal class ZNS: CommonNamingService, NamingService {
         "mainnet": "0x9611c53be6d1b32058b2747bdececed7e1216793"
     ]
 
+    static let znsNetworkIds = ["mainnet": "1",
+                                "testnet": "333",
+                                "isolated": "222"]
+
     init(_ config: NamingServiceConfig) throws {
 
         self.network = config.network.isEmpty
-            ? Self.getNetworkFromUrl(config.providerUrl)
+            ? try Self.getNetworkFromUrl(config.providerUrl, with: config.networking)
             : config.network
 
         guard let registryAddress = registryMap[self.network] else {
@@ -30,13 +34,39 @@ internal class ZNS: CommonNamingService, NamingService {
         super.init(name: "ZNS", providerUrl: config.providerUrl, networking: config.networking)
     }
 
-    static func getNetworkFromUrl(_ url: String) -> String {
-        if url.contains("dev-zilliqa") {
-            return "testnet"
-        } else if url.contains("api.zilliqa") {
-            return "mainnet"
+    static func getNetworkFromUrl(_ providerUrl: String, with networking: NetworkingLayer) throws -> String {
+
+        let url = URL(string: providerUrl)!
+        let payload: JsonRpcPayload = JsonRpcPayload(jsonrpc: "2.0", id: "67", method: "GetNetworkId", params: [])
+
+        var resp: JsonRpcResponseArray?
+        var err: Error?
+        let semaphore = DispatchSemaphore(value: 0)
+
+        networking.makeHttpPostRequest(
+            url: url,
+            httpMethod: "POST",
+            httpHeaderContentType: "application/json",
+            httpBody: try JSONEncoder().encode(payload)
+        ) { result in
+            switch result {
+            case .success(let response):
+                resp = response
+            case .failure(let error):
+                err = error
+            }
+            semaphore.signal()
         }
-        return ""
+        semaphore.wait()
+        guard err == nil else {
+            throw err!
+        }
+        switch resp?[0].result {
+        case .string(let result):
+            return znsNetworkIds.key(forValue: result) ?? ""
+        default:
+            return ""
+        }
     }
 
     func isSupported(domain: String) -> Bool {
@@ -47,7 +77,7 @@ internal class ZNS: CommonNamingService, NamingService {
         let recordAddresses = try self.recordsAddresses(domain: domain)
         let (ownerAddress, _ ) = recordAddresses
         guard Utillities.isNotEmpty(ownerAddress) else {
-                throw ResolutionError.unregisteredDomain
+            throw ResolutionError.unregisteredDomain
         }
 
         return ownerAddress
@@ -112,8 +142,8 @@ internal class ZNS: CommonNamingService, NamingService {
             let record = records[namehash] as? [String: Any],
             let arguments = record["arguments"] as? [Any], arguments.count == 2,
             let ownerAddress = arguments[0] as? String, let resolverAddress = arguments[1] as? String
-            else {
-                throw ResolutionError.unregisteredDomain
+        else {
+            throw ResolutionError.unregisteredDomain
         }
 
         return (ownerAddress, resolverAddress)
@@ -123,18 +153,23 @@ internal class ZNS: CommonNamingService, NamingService {
         let resolverContract: ContractZNS = self.buildContract(address: address)
 
         guard let records = try resolverContract.fetchSubState(
-                    field: "records",
-                    keys: keys
-                  ) as? [String: Any]
+            field: "records",
+            keys: keys
+        ) as? [String: Any]
         else {
             throw ResolutionError.unspecifiedResolver
         }
 
-      return records
+        return records
     }
 
     func buildContract(address: String) -> ContractZNS {
         return ContractZNS(providerUrl: self.providerUrl, address: address.replacingOccurrences(of: "0x", with: ""), networking: networking)
     }
+}
 
+fileprivate extension Dictionary where Value: Equatable {
+    func key(forValue value: Value) -> Key? {
+        return first { $0.1 == value }?.0
+    }
 }

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -86,6 +86,14 @@ public class Resolution {
         self.services = try constructNetworkServices(configs)
     }
 
+    /// Returns a network that NamingService was configure with
+    public func getNetwork(from serviceName: String) throws -> String {
+        guard let service = services.first(where: {$0.name == serviceName.uppercased() }) else {
+            throw ResolutionError.unsupportedServiceName
+        }
+        return service.network
+    }
+
     /// Checks if the domain name is valid according to naming service rules for valid domain names.
     ///
     /// **Example:** ENS doesn't allow domains that start from '-' symbol.

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -366,7 +366,7 @@ public class Resolution {
             errorService = error
         }
 
-        if let error = errorService, networkServices.isEmpty {
+        if let error = errorService {
             throw error
         }
         return networkServices

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -35,6 +35,7 @@ import Foundation
 /// }
 /// ```
 /// You can configure namingServices by providing NamingServiceConfig struct to the constructor for the interested service
+/// If you ommit network we are making a "net_version" JSON RPC call to the provider to determine the chainID
 /// for example lets configure crypto naming service to use rinkeby while left etherium naming service with default configurations:
 /// ```swift
 /// let resolution = try Resolution(

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -45,6 +45,26 @@ class ResolutionTests: XCTestCase {
         assert(znsNetwork == "mainnet");
     }
     
+    func testUnsupportedNetwork() throws {
+        self.checkError(completion: {
+            try Resolution(configs: Configurations(
+                cns: NamingServiceConfig(providerUrl: "https://ropsten.infura.io/v3/3c25f57353234b1b853e9861050f4817")
+            ));
+        }, expectedError: .unsupportedNetwork)
+        
+        self.checkError(completion: {
+            try Resolution(configs: Configurations(
+                zns: NamingServiceConfig(providerUrl: "https://dev-api.zilliqa.com")
+            ));
+        }, expectedError: .unsupportedNetwork)
+        
+        self.checkError(completion: {
+            try Resolution(configs: Configurations(
+                ens: NamingServiceConfig(providerUrl: "https://kovan.infura.io/v3/3c25f57353234b1b853e9861050f4817")
+            ));
+        }, expectedError: .unsupportedNetwork)
+    }
+    
     func testRinkeby() throws {
         resolution = try Resolution(configs: Configurations(
                 cns: NamingServiceConfig(

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -30,6 +30,21 @@ class ResolutionTests: XCTestCase {
         try testAddr();
     }
     
+    func testNetworkFromUrl() throws {
+        resolution = try Resolution(configs: Configurations(
+            cns: NamingServiceConfig(providerUrl: "https://rinkeby.infura.io/v3/3c25f57353234b1b853e9861050f4817"),
+            ens: NamingServiceConfig(providerUrl: "https://ropsten.infura.io/v3/3c25f57353234b1b853e9861050f4817")
+            )
+        );
+        
+        let cnsNetwork = try resolution.getNetwork(from: "cns");
+        let ensNetwork = try resolution.getNetwork(from: "ens");
+        let znsNetwork = try resolution.getNetwork(from: "zns");
+        assert(cnsNetwork == "rinkeby");
+        assert(ensNetwork == "ropsten");
+        assert(znsNetwork == "mainnet");
+    }
+    
     func testRinkeby() throws {
         resolution = try Resolution(configs: Configurations(
                 cns: NamingServiceConfig(
@@ -574,6 +589,8 @@ extension ResolutionError: Equatable {
             return true
         case (.badRequestOrResponse, .badRequestOrResponse):
             return true
+        case (.unsupportedServiceName, .unsupportedServiceName):
+            return true
             
         // We don't use `default` here on purpose, so we don't forget updating this method on adding new variants.
         case (.unregisteredDomain, _),
@@ -587,8 +604,13 @@ extension ResolutionError: Equatable {
              (.methodNotSupported, _),
              (.proxyReaderNonInitialized, _),
              (.tooManyResponses, _),
-             (.badRequestOrResponse, _):
+             (.badRequestOrResponse, _),
+             (.unsupportedServiceName, _):
             
+            return false
+        // Xcode with Version 12.4 (12D4e) can't compile this without default
+        // throws error: The compiler is unable to check that this switch is exhaustive in reasonable time
+        default:
             return false
         }
     }

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -621,6 +621,10 @@ extension ResolutionError: Equatable {
              (.unsupportedServiceName, _):
             
             return false
+        // Xcode with Version 12.4 (12D4e) can't compile this without default
+        // throws error: The compiler is unable to check that this switch is exhaustive in a reasonable time
+        default:
+            return false
         }
     }
 }

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -54,12 +54,6 @@ class ResolutionTests: XCTestCase {
         
         self.checkError(completion: {
             try Resolution(configs: Configurations(
-                zns: NamingServiceConfig(providerUrl: "https://dev-api.zilliqa.com")
-            ));
-        }, expectedError: .unsupportedNetwork)
-        
-        self.checkError(completion: {
-            try Resolution(configs: Configurations(
                 ens: NamingServiceConfig(providerUrl: "https://kovan.infura.io/v3/3c25f57353234b1b853e9861050f4817")
             ));
         }, expectedError: .unsupportedNetwork)
@@ -626,10 +620,6 @@ extension ResolutionError: Equatable {
              (.badRequestOrResponse, _),
              (.unsupportedServiceName, _):
             
-            return false
-        // Xcode with Version 12.4 (12D4e) can't compile this without default
-        // throws error: The compiler is unable to check that this switch is exhaustive in a reasonable time
-        default:
             return false
         }
     }

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -612,7 +612,6 @@ extension ResolutionError: Equatable {
         case (.unsupportedServiceName, .unsupportedServiceName):
             return true
             
-        // We don't use `default` here on purpose, so we don't forget updating this method on adding new variants.
         case (.unregisteredDomain, _),
              (.unsupportedDomain, _),
              (.recordNotFound, _),
@@ -629,7 +628,7 @@ extension ResolutionError: Equatable {
             
             return false
         // Xcode with Version 12.4 (12D4e) can't compile this without default
-        // throws error: The compiler is unable to check that this switch is exhaustive in reasonable time
+        // throws error: The compiler is unable to check that this switch is exhaustive in a reasonable time
         default:
             return false
         }


### PR DESCRIPTION
This PR allows us to not configure the network manually. Some of the clients don't have a flexible enough system to get the network automatically. 

Initializing the library in the following way:
```swift
resolution = try Resolution(configs: Configurations(
    cns: NamingServiceConfig(providerUrl: "https://rinkeby.infura.io/v3/3c25f57353234b1b853e9861050f4817"),
    ens: NamingServiceConfig(providerUrl: "https://ropsten.infura.io/v3/3c25f57353234b1b853e9861050f4817")
    )
);
```
gives us CNS that connected to the rinkeby and ENS that is connected to the ropsten. 

* For Etherium we are making a "net_version" JSON RPC call to the provider to get the chainId if no network was supplied.
* We are not making any request to Zilliqa as we don't support testnet or any others.


_**P.S I made it so the wrong configuration on any namingService will trigger a throw. Before we could misconfigure CNS or ENS and the error was silenced if any other services were correct.**_

_**P.S.S I am using Xcode Version 12.4 (12D4e) and I wasn't able to compile the tests without adding a default case. 
It throws**_ `The compiler is unable to check that this switch is exhaustive in a reasonable time.` 