### PR TITLE
general multichain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ resolution.addr(domain: "brad.crypto", ticker: "eth") { result in
   }
 }
 
-resolution.multiChainAddress(domain: "brad.crypto", ticker: "USDT", version: "ERC20") { result in
+resolution.multiChainAddress(domain: "brad.crypto", ticker: "USDT", chain: "ERC20") { result in
   switch result {
   case .success(let returnValue):
     // 0x8aaD44321A86b170879d7A244c1e8d360c99DdA8
@@ -90,7 +90,7 @@ resolution.multiChainAddress(domain: "brad.crypto", ticker: "USDT", version: "ER
   }
 }
 
-resolution.multiChainAddress(domain: "brad.crypto", ticker: "USDT", version: "OMNI") { result in
+resolution.multiChainAddress(domain: "brad.crypto", ticker: "USDT", chain: "OMNI") { result in
   switch result {
   case .success(let returnValue):
     // 1FoWyxwPXuj4C6abqwhjDWdz6D4PZgYRjA

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ package.dependencies.append(
 ```swift
 import UnstoppableDomainsResolution
 
-  ...
-
 guard let resolution = try? Resolution() else {
   print ("Init of Resolution instance with default parameters failed...")
   return
@@ -79,6 +77,26 @@ resolution.addr(domain: "brad.crypto", ticker: "eth") { result in
     let ethAddress = returnValue
   case .failure(let error):
     print("Expected eth Address, but got \(error)")
+  }
+}
+
+resolution.multiChainAddress(domain: "brad.crypto", ticker: "USDT", version: "ERC20") { result in
+  switch result {
+  case .success(let returnValue):
+    // 0x8aaD44321A86b170879d7A244c1e8d360c99DdA8
+    let usdtErc20Address = returnValue
+  case .failure(let error):
+    print("Expected eth Address, but got \(error)")
+  }
+}
+
+resolution.multiChainAddress(domain: "brad.crypto", ticker: "USDT", version: "OMNI") { result in
+  switch result {
+  case .success(let returnValue):
+    // 1FoWyxwPXuj4C6abqwhjDWdz6D4PZgYRjA
+    let usdtOmniAddress = returnValue
+  case .failure(let error):
+    print("Expected Omni Address, but got \(error)")
   }
 }
 

--- a/Sources/UnstoppableDomainsResolution/ABI/EthereumABI/ABIElements.swift
+++ b/Sources/UnstoppableDomainsResolution/ABI/EthereumABI/ABIElements.swift
@@ -37,7 +37,7 @@ public extension ABI {
     }
 
     enum Element {
-        public enum ArraySize { //bytes for convenience
+        public enum ArraySize { // bytes for convenience
             case staticSize(UInt64)
             case dynamicSize
             case notArray

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -182,8 +182,8 @@ public class Resolution {
 
     /// Resolves a multiChainAddress of a `domain` for specific `chain`
     /// - Parameter domain: - domain name to be resolved
-    /// - Parameter ticker: - currency ticker like USDT, FTM, etc.
-    /// - Parameter chain: - usually means blockchain such as ERC20, OMNI,  TRON and etc.
+    /// - Parameter ticker: - currency ticker like USDT, FTM and others
+    /// - Parameter chain: - chain version like ERC20, OMNI, TRON and others
     /// - Parameter completion: A callback that resolves `Result` with a `multiChain Address` for a specific ticker and chain
     public func multiChainAddress(domain: String, ticker: String, chain: String, completion: @escaping StringResultConsumer ) {
         let preparedDomain = prepare(domain: domain)

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -180,6 +180,30 @@ public class Resolution {
         }
     }
 
+    /// Resolves a multiChainAddress of a `domain` for specific `chain`
+    /// - Parameter domain: - domain name to be resolved
+    /// - Parameter ticker: - currency ticker like USDT, FTM, etc.
+    /// - Parameter chain: - usually means blockchain such as ERC20, OMNI,  TRON and etc.
+    /// - Parameter completion: A callback that resolves `Result` with a `multiChain Address` for a specific ticker and chain
+    public func multiChainAddress(domain: String, ticker: String, chain: String, completion: @escaping StringResultConsumer ) {
+        let preparedDomain = prepare(domain: domain)
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            do {
+                guard let service = try self?.getServiceOf(domain: preparedDomain),
+                      service.name != "ENS" else {
+                    throw ResolutionError.methodNotSupported
+                }
+                let recordKey = "crypto.\(ticker.uppercased()).version.\(chain.uppercased()).address"
+                let result = try service.record(domain: preparedDomain, key: recordKey)
+                completion(.success(result))
+            } catch {
+                self?.catchError(error, completion: completion)
+            }
+        }
+    }
+
+    // TODO: remove this in 1.0.0
+    @available(*, deprecated, message: "Please use ```public func multiChainAddress(domain: String, ticker: String, chain: String) instead```")
     public func usdt(domain: String, version: UsdtVersion, completion: @escaping StringResultConsumer ) {
         let preparedDomain = prepare(domain: domain)
         DispatchQueue.global(qos: .utility).async { [weak self] in

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -117,6 +117,82 @@ class ResolutionTests: XCTestCase {
         
     }
     
+    func testMultiChainAddress() throws {
+        // Given
+        let domain: String = "udtestdev-usdt.crypto";
+        
+        let erc20Received = expectation(description: "Erc20 record should be received");
+        var erc20: String = "";
+        
+        let tronReceived = expectation(description: "tron record should be received");
+        var tron: String = "";
+        
+        let eosReceived = expectation(description: "eos record should be received");
+        var eos: String = "";
+        
+        let omniReceived = expectation(description: "omni record should be received");
+        var omni: String = "";
+        
+        let NoRecordReceived = expectation(description: "no record error should be received")
+        var NoRecordResult: Result<String, ResolutionError>!
+        
+        // When
+        resolution.multiChainAddress(domain: "brad.crypto", ticker: "usdt", chain: "erc20") {
+            NoRecordResult = $0
+            NoRecordReceived.fulfill()
+        }
+        
+        resolution.multiChainAddress(domain: domain, ticker: "usdt", chain: "erc20") { (result) in
+            switch result {
+            case .success(let returnValue):
+                erc20Received.fulfill();
+                erc20 = returnValue;
+            case .failure(let error):
+                XCTFail("Expected erc20 usdt address, but got \(error)")
+            }
+        }
+
+        resolution.multiChainAddress(domain: domain, ticker: "usdt", chain: "eos") { (result) in
+            switch result {
+            case .success(let returnValue):
+                eosReceived.fulfill();
+                eos = returnValue;
+            case .failure(let error):
+                XCTFail("Expected eos usdt address, but got \(error)")
+            }
+        }
+
+        resolution.multiChainAddress(domain: domain, ticker: "usdt", chain: "tron") { (result) in
+            switch result {
+            case .success(let returnValue):
+                tronReceived.fulfill();
+                tron = returnValue;
+            case .failure(let error):
+                XCTFail("Expected tron usdt address, but got \(error)")
+            }
+        }
+
+        resolution.multiChainAddress(domain: domain, ticker: "usdt", chain: "omni") { (result) in
+            switch result {
+            case .success(let returnValue):
+                omniReceived.fulfill();
+                omni = returnValue;
+            case .failure(let error):
+                XCTFail("Expected omni usdt address, but got \(error)")
+            }
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        assert(erc20 == "0xe7474D07fD2FA286e7e0aa23cd107F8379085037")
+        assert(eos == "letsminesome")
+        assert(omni == "19o6LvAdCPkjLi83VsjrCsmvQZUirT4KXJ")
+        assert(tron == "TNemhXhpX7MwzZJa3oXvfCjo5pEeXrfN2h")
+        self.checkError(result: NoRecordResult, expectedError: ResolutionError.recordNotFound)
+    }
+    
+    // TODO: remove this in 1.0.0
     func testUsdtVersion() throws {
         // Given
         let domain: String = "udtestdev-usdt.crypto";


### PR DESCRIPTION
Since we have more encounters with the multi-chain tokens such as FTM and USDT, we decided to deprecate getUsdt in favor of the more general method getMultiChainAddress. 
