### PR TITLE
UnregisteredDomain instead of UnspecifiedResolver

### DIFF
--- a/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/CNS.swift
@@ -198,8 +198,11 @@ internal class CNS: CommonNamingService, NamingService {
             if let owners = unfoldAddressForMany(dict[Contract.ownersKey]),
                let resolvers = unfoldAddressForMany(dict[Contract.resolversKey]),
                let valuesArray = dict[Contract.valuesKey] as? [[String]] {
-                guard Utillities.isNotEmpty(owners[0]),
-                      Utillities.isNotEmpty(resolvers[0]),
+                guard Utillities.isNotEmpty(owners[0]) else {
+                    throw ResolutionError.unregisteredDomain
+                }
+
+                guard Utillities.isNotEmpty(resolvers[0]),
                       valuesArray.count > 0,
                       valuesArray[0].count > 0 else {
                     throw ResolutionError.unspecifiedResolver

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -59,6 +59,17 @@ class ResolutionTests: XCTestCase {
         }, expectedError: .unsupportedNetwork)
     }
     
+    func testForUnregisteredDomain() throws {
+        let UnregirestedDomainExpectation = expectation(description: "Domain should not be registered!")
+        var NoRecordResult: Result<String, ResolutionError>!
+        resolution.addr(domain: "unregistered.crypto", ticker: "eth") {
+            NoRecordResult = $0
+            UnregirestedDomainExpectation.fulfill();
+        }
+        waitForExpectations(timeout: timeout, handler: nil)
+        self.checkError(result: NoRecordResult, expectedError: ResolutionError.unregisteredDomain)
+    }
+    
     func testRinkeby() throws {
         resolution = try Resolution(configs: Configurations(
                 cns: NamingServiceConfig(
@@ -549,9 +560,9 @@ class ResolutionTests: XCTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        assert(hash == "Qme54oEzRkgooJbCDr78vzKAWcv6DDEZqRhhDyDtzgrZP6")
+        assert(hash == "QmdyBw5oTgCtTLQ18PbDvPL8iaLoEPhSyzD91q9XmgmAjb")
         assert(etcHash == "QmXSBLw6VMegqkCHSDBPg7xzfLhUyuRBzTb927KVzKC1vq")
-        self.checkError(result: unregisteredResult, expectedError: ResolutionError.unspecifiedResolver)
+        self.checkError(result: unregisteredResult, expectedError: ResolutionError.unregisteredDomain)
     }
 
     func testCustomRecord() throws {
@@ -581,7 +592,7 @@ class ResolutionTests: XCTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        assert(ipfshash == "Qme54oEzRkgooJbCDr78vzKAWcv6DDEZqRhhDyDtzgrZP6")
+        assert(ipfshash == "QmdyBw5oTgCtTLQ18PbDvPL8iaLoEPhSyzD91q9XmgmAjb")
         self.checkError(result: unregisteredResult, expectedError: ResolutionError.recordNotFound)
     }
 
@@ -607,7 +618,7 @@ class ResolutionTests: XCTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        assert(values["ipfs.html.value"] == "Qme54oEzRkgooJbCDr78vzKAWcv6DDEZqRhhDyDtzgrZP6")
+        assert(values["ipfs.html.value"] == "QmdyBw5oTgCtTLQ18PbDvPL8iaLoEPhSyzD91q9XmgmAjb")
         assert(values["crypto.BTC.address"] == "bc1q359khn0phg58xgezyqsuuaha28zkwx047c0c3y")
         assert(values["crypto.ETH.address"] == "0x8aaD44321A86b170879d7A244c1e8d360c99DdA8")
         assert(values["someweirdstuf"] == "")

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -70,6 +70,17 @@ class ResolutionTests: XCTestCase {
         self.checkError(result: NoRecordResult, expectedError: ResolutionError.unregisteredDomain)
     }
     
+    func testForUnspecifiedResolver() throws {
+        let UnregirestedDomainExpectation = expectation(description: "Domain should not have a Resolver!")
+        var NoRecordResult: Result<String, ResolutionError>!
+        resolution.addr(domain: "twistedmusic.crypto", ticker: "eth") {
+            NoRecordResult = $0
+            UnregirestedDomainExpectation.fulfill();
+        }
+        waitForExpectations(timeout: timeout, handler: nil)
+        self.checkError(result: NoRecordResult, expectedError: ResolutionError.unspecifiedResolver)
+    }
+    
     func testRinkeby() throws {
         resolution = try Resolution(configs: Configurations(
                 cns: NamingServiceConfig(


### PR DESCRIPTION
Found a little mixup with the error code the library has been spitting out when was doing the gnosis integration. When I query anything from a domain that is not registered, I expect to get unregisteredDomain instead of UnspecifiedResolver error. 

Even though the chances of having ownership of a domain with no resolvers set are extremely low. The only domain like that I could found was paulalcock.zil. 

I guess this is considered to be a breaking change. Would love to hear some opinions regarding this. 