### PR TITLE
Add ability to import owned tokens to resolution-swift library

### DIFF
--- a/Resolution.xcodeproj/xcshareddata/xcschemes/resolution.xcscheme
+++ b/Resolution.xcodeproj/xcshareddata/xcschemes/resolution.xcscheme
@@ -17,7 +17,7 @@
                BlueprintIdentifier = "3EE4DA0224E367720097540B"
                BuildableName = "Resolution.framework"
                BlueprintName = "UnstoppableDomainsResolution"
-               ReferencedContainer = "container:Resolution.xcodeproj">
+               ReferencedContainer = "container:resolution.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -35,7 +35,7 @@
                BlueprintIdentifier = "3EE4DA0B24E367720097540B"
                BuildableName = "ResolutionTests.xctest"
                BlueprintName = "ResolutionTests"
-               ReferencedContainer = "container:Resolution.xcodeproj">
+               ReferencedContainer = "container:resolution.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
@@ -63,7 +63,7 @@
             BlueprintIdentifier = "3EE4DA0224E367720097540B"
             BuildableName = "Resolution.framework"
             BlueprintName = "UnstoppableDomainsResolution"
-            ReferencedContainer = "container:Resolution.xcodeproj">
+            ReferencedContainer = "container:resolution.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
    </ProfileAction>

--- a/Sources/UnstoppableDomainsResolution/ABI/JSON_RPC.swift
+++ b/Sources/UnstoppableDomainsResolution/ABI/JSON_RPC.swift
@@ -35,10 +35,23 @@ public struct JsonRpcPayload: Codable {
                     ParamElement.string("latest")
                   ])
     }
+
+    init (params: ParamLogClass) {
+        self.init(
+            jsonrpc: "2.0",
+              id: "1.0",
+              method: "eth_getLogs",
+              params: [
+                  ParamElement.paramLogClass(params)
+              ]
+        )
+    }
 }
 
 public enum ParamElement: Codable {
     case paramClass(ParamClass)
+    case paramLogClass(ParamLogClass)
+    case paramLogResponse(JsonRpcLogResponse)
     case string(String)
     case array([ParamElement])
     case dictionary([String: ParamElement])
@@ -51,6 +64,14 @@ public enum ParamElement: Codable {
         }
         if let elem = try? container.decode(ParamClass.self) {
             self = .paramClass(elem)
+            return
+        }
+        if let elem = try? container.decode(ParamLogClass.self) {
+            self = .paramLogClass(elem)
+            return
+        }
+        if let elem = try? container.decode(JsonRpcLogResponse.self) {
+            self = .paramLogResponse(elem)
             return
         }
         if let elem = try? container.decode(Array<ParamElement>.self) {
@@ -74,6 +95,10 @@ public enum ParamElement: Codable {
         switch self {
         case .paramClass(let elem):
             try container.encode(elem)
+        case .paramLogClass(let elem):
+            try container.encode(elem)
+        case .paramLogResponse(let elem):
+            try container.encode(elem)
         case .string(let elem):
             try container.encode(elem)
         case .array(let array):
@@ -87,6 +112,24 @@ public enum ParamElement: Codable {
 public struct ParamClass: Codable {
     let data: String
     let to: String
+}
+
+public struct ParamLogClass: Codable {
+    let fromBlock: String
+    let address: String
+    let topics: [String?]
+}
+
+public struct JsonRpcLogResponse: Codable {
+    let address: String
+    let blockHash: String
+    let blockNumber: String
+    let data: String
+    let logIndex: String
+    let removed: Bool
+    let topics: [String]
+    let transactionHash: String
+    let transactionIndex: String
 }
 
 public struct JsonRpcResponse: Decodable {

--- a/Sources/UnstoppableDomainsResolution/Contract.swift
+++ b/Sources/UnstoppableDomainsResolution/Contract.swift
@@ -31,10 +31,10 @@ internal class Contract {
         self.networking = networking
     }
 
-    func callMethod(methodName: String, args: [Any]) throws -> Any {
+    func callMethod(methodName: String, args: [Any]) throws -> Any? {
         let encodedData = try self.coder.encode(method: methodName, args: args)
         let body = JsonRpcPayload(id: "1", data: encodedData, to: address)
-        let response = try postRequest(body)!
+        let response = try postRequestForString(body)!
         return try self.coder.decode(response, from: methodName)
     }
 
@@ -58,9 +58,42 @@ internal class Contract {
             }
             return IdentifiableResult<Any?>(id: responseElement.id, result: res)
         }
-}
+    }
 
-    private func postRequest(_ body: JsonRpcPayload) throws -> String? {
+    func callLogs(fromBlock: String, signatureHash: String, for userAddress: String, isTransfer: Bool ) throws  -> [JsonRpcLogResponse] {
+        let topics = isTransfer ? [signatureHash, nil, userAddress ] : [signatureHash, userAddress]
+        let params = ParamLogClass(fromBlock: fromBlock, address: self.address, topics: topics)
+        let body = JsonRpcPayload(params: params)
+
+        return try postRequestForLogArray(body) ?? []
+    }
+
+    private func postRequestForLogArray(_ body: JsonRpcPayload) throws -> [JsonRpcLogResponse]? {
+        let postResponse = try postRequest(body)
+        if case .array(let arrayOfElements) = postResponse {
+            return arrayOfElements.compactMap {
+                switch $0 {
+                case .paramLogResponse(let val):
+                    return val
+                case _:
+                    return nil
+                }
+            }
+        }
+        return []
+    }
+
+    private func postRequestForString(_ body: JsonRpcPayload) throws -> String? {
+        let postResponse = try postRequest(body)
+        switch postResponse {
+        case .string(let result):
+            return result
+        default:
+            return nil
+        }
+    }
+
+    private func postRequest(_ body: JsonRpcPayload) throws -> ParamElement? {
         let postRequest = APIRequest(providerUrl, networking: networking)
         var resp: JsonRpcResponseArray?
         var err: Error?
@@ -78,12 +111,7 @@ internal class Contract {
         guard err == nil else {
             throw err!
         }
-        switch resp?[0].result {
-        case .string(let result):
-            return result
-        default:
-            return nil
-        }
+       return resp?[0].result
     }
 
     private func postBatchRequest(_ bodyArray: [JsonRpcPayload]) throws -> [IdentifiableResult<String>?] {

--- a/Sources/UnstoppableDomainsResolution/Contract.swift
+++ b/Sources/UnstoppableDomainsResolution/Contract.swift
@@ -31,7 +31,7 @@ internal class Contract {
         self.networking = networking
     }
 
-    func callMethod(methodName: String, args: [Any]) throws -> Any? {
+    func callMethod(methodName: String, args: [Any]) throws -> Any {
         let encodedData = try self.coder.encode(method: methodName, args: args)
         let body = JsonRpcPayload(id: "1", data: encodedData, to: address)
         let response = try postRequestForString(body)!

--- a/Sources/UnstoppableDomainsResolution/ContractZNS.swift
+++ b/Sources/UnstoppableDomainsResolution/ContractZNS.swift
@@ -78,6 +78,10 @@ internal class ContractZNS {
                 dict[key] = self.map(array: array)
             case .dictionary(let dictionary):
                 dict[key] = self.reduce(dict: dictionary)
+            case .paramLogClass(let elem):
+                dict[key] = elem
+            case .paramLogResponse(let elem):
+                dict[key] = elem
             }
         }
     }
@@ -86,6 +90,10 @@ internal class ContractZNS {
         return array.map { (value) -> Any in
             switch value {
             case .paramClass(let elem):
+                return elem
+            case .paramLogClass(let elem):
+                return elem
+            case .paramLogResponse(let elem):
                 return elem
             case .string(let elem):
                 return elem

--- a/Sources/UnstoppableDomainsResolution/NamingServices/ZNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/ZNS.swift
@@ -46,6 +46,10 @@ internal class ZNS: CommonNamingService, NamingService {
         throw ResolutionError.methodNotSupported
     }
 
+    func tokensOwnedBy(address: String) throws -> [String] {
+        throw ResolutionError.methodNotSupported
+    }
+
     func addr(domain: String, ticker: String) throws -> String {
         let key = "crypto.\(ticker.uppercased()).address"
         let result = try record(domain: domain, key: key)

--- a/Sources/UnstoppableDomainsResolution/Protocols/NamingService.swift
+++ b/Sources/UnstoppableDomainsResolution/Protocols/NamingService.swift
@@ -17,6 +17,7 @@ protocol NamingService {
     func isSupported(domain: String) -> Bool
 
     func owner(domain: String) throws -> String
+    func tokensOwnedBy(address: String) throws -> [String]
     func addr(domain: String, ticker: String) throws -> String
     func resolver(domain: String) throws -> String
 

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -141,6 +141,24 @@ public class Resolution {
         }
     }
 
+    /// Returns domains owned by `address`
+    /// - Parameter address: - address of a user you want to get domains of
+    /// - Parameter service: - name of the service you want to check agains CNS or ZNS
+    /// - Parameter completion: - A callback taht resolves `Result` with an `array of domain names` or `Error`
+    public func tokensOwnedBy(address: String, service: String, completion: @escaping StringsArrayResultConsumer ) {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            do {
+                guard let service = self?.services.first(where: { $0.name == service }) else {
+                    throw ResolutionError.recordNotFound
+                }
+                let result = try service.tokensOwnedBy(address: address)
+                completion(.success(result))
+            } catch {
+                self?.catchError(error, completion: completion)
+            }
+        }
+    }
+
     /// Resolves a resolver address of a `domain`
     /// - Parameter  domain: - domain name to be resolved
     /// - Parameter  completion: A callback that resolves `Result`  with a `resolver address` for a specific domain or `Error`

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -149,7 +149,7 @@ public class Resolution {
         DispatchQueue.global(qos: .utility).async { [weak self] in
             do {
                 guard let service = self?.services.first(where: { $0.name == service }) else {
-                    throw ResolutionError.recordNotFound
+                    throw ResolutionError.unsupportedServiceName
                 }
                 let result = try service.tokensOwnedBy(address: address)
                 completion(.success(result))

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -436,6 +436,34 @@ class ResolutionTests: XCTestCase {
         assert(chatID == "0x8912623832e174f2eb1f59cc3b587444d619376ad5bf10070e937e0dc22b9ffb2e3ae059e6ebf729f87746b2f71e5d88ec99c1fb3c7c49b8617e2520d474c48e1c")
     }
     
+    func testForTokensOwnedByCns() throws {
+        let tetReceived = expectation(description: "This is just for test");
+        let resolutionB = try Resolution(configs: Configurations(
+                 cns: NamingServiceConfig(
+                   providerUrl: "https://mainnet.infura.io/v3/e05c36b6b2134ccc9f2594ddff94c136",
+                   network: "mainnet"
+                )
+        ))
+        var returnedDomains: [String] = [];
+        resolutionB.tokensOwnedBy(address: "0x8aaD44321A86b170879d7A244c1e8d360c99DdA8", service: "CNS") { (result) in
+            switch result {
+            case .success(let returnValue):
+                returnedDomains = returnValue.compactMap{ $0 }
+                tetReceived.fulfill()
+            case .failure(let error):
+                XCTFail("something went wrong \(error)")
+            }
+
+        }
+        waitForExpectations(timeout: timeout, handler: nil)
+        assert(returnedDomains.count == 4)
+        assert(returnedDomains.contains("checkoutwithadomain.crypto"))
+        assert(returnedDomains.contains("brad.crypto"))
+        assert(returnedDomains.contains("bradley.chat.crypto"))
+        assert(returnedDomains.contains("kdslkfjadasdfd.crypto"))
+    }
+    
+    
     func testIpfs() throws {
         // Given
         let domainReceived = expectation(description: "Exist domain should be received")

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -74,12 +74,22 @@ class ResolutionTests: XCTestCase {
             )
         );
         let domainReceived = expectation(description: "Exist domain should be received")
+        let ownerReceived = expectation(description: "Exist domain should be received")
         var ethAddress = ""
         resolution.addr(domain: "udtestdev-creek.crypto", ticker: "eth") { (result) in
             switch result {
             case .success(let returnValue):
                 ethAddress = returnValue
                 domainReceived.fulfill()
+            case .failure(let error):
+                XCTFail("Expected Eth Address, but got \(error)")
+            }
+        }
+        resolution.owner(domain: "udtestdev-creek.crypto") { (result) in
+            switch result {
+            case .success(let returnValue):
+                print(returnValue)
+                ownerReceived.fulfill()
             case .failure(let error):
                 XCTFail("Expected Eth Address, but got \(error)")
             }
@@ -437,15 +447,41 @@ class ResolutionTests: XCTestCase {
     }
     
     func testForTokensOwnedByCns() throws {
-        let tetReceived = expectation(description: "This is just for test");
-        let resolutionB = try Resolution(configs: Configurations(
+        let tokenReceived = expectation(description: "tokens for 0x8aaD44321A86b170879d7A244c1e8d360c99DdA8 address should be received");
+        let resolution = try Resolution(configs: Configurations(
                  cns: NamingServiceConfig(
                    providerUrl: "https://mainnet.infura.io/v3/e05c36b6b2134ccc9f2594ddff94c136",
                    network: "mainnet"
                 )
         ))
         var returnedDomains: [String] = [];
-        resolutionB.tokensOwnedBy(address: "0x8aaD44321A86b170879d7A244c1e8d360c99DdA8", service: "CNS") { (result) in
+        resolution.tokensOwnedBy(address: "0x8aaD44321A86b170879d7A244c1e8d360c99DdA8", service: "CNS") { (result) in
+            switch result {
+            case .success(let returnValue):
+                returnedDomains = returnValue.compactMap{ $0 }
+                tokenReceived.fulfill()
+            case .failure(let error):
+                XCTFail("something went wrong \(error)")
+            }
+
+        }
+        waitForExpectations(timeout: timeout, handler: nil)
+        assert(returnedDomains.count >= 4)
+        assert(returnedDomains.contains("checkoutwithadomain.crypto"))
+        assert(returnedDomains.contains("brad.crypto"))
+        assert(returnedDomains.contains("bradley.chat.crypto"))
+        assert(returnedDomains.contains("kdslkfjadasdfd.crypto"))
+    }
+    
+    func testForTokensOwnedByCnsFromRinkeby() throws {
+        let tetReceived = expectation(description: "This is just for test");
+        let resolutionB = try Resolution(configs: Configurations(
+            cns: NamingServiceConfig(
+                providerUrl: "https://rinkeby.infura.io/v3/e05c36b6b2134ccc9f2594ddff94c136",
+                network: "rinkeby"
+            )))
+        var returnedDomains: [String] = [];
+        resolutionB.tokensOwnedBy(address: "0x6EC0DEeD30605Bcd19342f3c30201DB263291589", service: "CNS") { (result) in
             switch result {
             case .success(let returnValue):
                 returnedDomains = returnValue.compactMap{ $0 }
@@ -457,12 +493,11 @@ class ResolutionTests: XCTestCase {
         }
         waitForExpectations(timeout: timeout, handler: nil)
         assert(returnedDomains.count == 4)
-        assert(returnedDomains.contains("checkoutwithadomain.crypto"))
-        assert(returnedDomains.contains("brad.crypto"))
-        assert(returnedDomains.contains("bradley.chat.crypto"))
-        assert(returnedDomains.contains("kdslkfjadasdfd.crypto"))
+        assert(returnedDomains.contains("udtestdev-creek.crypto"))
+        assert(returnedDomains.contains("reseller-test-udtesting-630444001358.crypto"))
+        assert(returnedDomains.contains("test-test-test-test.crypto"))
+        assert(returnedDomains.contains("reseller-test-udtesting-483809515990.crypto"))
     }
-    
     
     func testIpfs() throws {
         // Given


### PR DESCRIPTION
Introduce Resolution#tokensOwnedBy(address: String, service: String) throws -> [String]

Cns#tokensOwnedBy fetches the registry contract for logs on the provided address, fetches NewURI to decrypt the domains
Zns is not supported at the moment.
https://www.pivotaltracker.com/story/show/178446775