### PR TITLE
small code duplication removal

### DIFF
--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -489,26 +489,7 @@ public class Resolution {
         throw ResolutionError.invalidDomainName
     }
 
-    /// Process the 'error'
-    private func catchError(_ error: Error, completion:@escaping DictionaryResultConsumer ) {
-        guard let catched = error as? ResolutionError else {
-            completion(.failure(.unknownError(error)))
-            return
-        }
-        completion(.failure(catched))
-    }
-
-    /// Process the 'error'
-    private func catchError(_ error: Error, completion:@escaping StringResultConsumer ) {
-        guard let catched = error as? ResolutionError else {
-            completion(.failure(.unknownError(error)))
-            return
-        }
-        completion(.failure(catched))
-    }
-
-    /// Process the 'error'
-    private func catchError(_ error: Error, completion:@escaping StringsArrayResultConsumer ) {
+    private func catchError<T>(_ error: Error, completion: @escaping (Result<T, ResolutionError>) -> Void) {
         guard let catched = error as? ResolutionError else {
             completion(.failure(.unknownError(error)))
             return
@@ -523,15 +504,6 @@ public class Resolution {
                 return
             }
             completion(.failure(catched))
-            return
-        }
-        completion(.failure(catched))
-    }
-
-    /// Process the 'error'
-    private func catchError(_ error: Error, completion:@escaping TokenUriMetadataResultConsumer ) {
-        guard let catched = error as? ResolutionError else {
-            completion(.failure(.unknownError(error)))
             return
         }
         completion(.failure(catched))

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -457,7 +457,7 @@ class ResolutionTests: XCTestCase {
 
         // Then
         assert(owner.lowercased() == "0xe7474D07fD2FA286e7e0aa23cd107F8379085037".lowercased())
-        assert(ethOwner.lowercased() == "0x714ef33943d925731fbb89c99af5780d888bd106".lowercased())
+        assert(ethOwner.lowercased() == "0xa59C818Ddb801f1253edEbf0Cf08c9E481EA2fE5".lowercased())
         self.checkError(result: unregisteredResult, expectedError: ResolutionError.unregisteredDomain)
     }
     


### PR DESCRIPTION
While I was working with L2 support I found that we can slightly reduce the duplication of our catchErrors functions. 
Unfortunately, I wasn't able to make it work for each method as DnsRecordsResultConsumer has a simple Error in its type.

`public typealias DnsRecordsResultConsumer = (Result<[DnsRecord], Error>) -> Void`
while all others are explicitly saying that Error is going to be ResolutionError.

Even though, I believe this is a good change as it reduces 4 duplicate functions into 1 more generic. I don't see the point of keeping them explicit either. 