### PR TITLE
Johnny/locations

### DIFF
--- a/Sources/UnstoppableDomainsResolution/Contract.swift
+++ b/Sources/UnstoppableDomainsResolution/Contract.swift
@@ -11,6 +11,11 @@ struct IdentifiableResult<T> {
     var result: T
 }
 
+struct MultiCallData {
+    let methodName: String
+    let args: [Any]
+}
+
 import Foundation
 internal class Contract {
     let batchIdOffset = 128
@@ -18,6 +23,7 @@ internal class Contract {
     static let ownersKey = "owners"
     static let resolversKey = "resolvers"
     static let valuesKey = "values"
+    static let multiCallMethodName = "multicall"
 
     let address: String
     let providerUrl: String
@@ -29,6 +35,19 @@ internal class Contract {
         self.providerUrl = providerUrl
         self.coder = ABICoder(abi)
         self.networking = networking
+    }
+
+    func multiCall(calls: [MultiCallData]) throws -> [Data] {
+        let encodedCalls = try calls.map { try self.coder.encode(method: $0.methodName, args: $0.args) }
+        let encodedMultiCall = try self.coder.encode(method: Self.multiCallMethodName, args: [encodedCalls])
+        let body = JsonRpcPayload(id: "1", data: encodedMultiCall, to: address)
+        let response = try postRequestForString(body)!
+        let decodedResponse = try self.coder.decode(response, from: Self.multiCallMethodName) as? [String: Any]
+        guard let decoded = decodedResponse,
+              let decodedResults = decoded["results"] as? [Data] else {
+            throw ABICoderError.couldNotDecode(method: "multicall", value: response)
+        }
+        return decodedResults
     }
 
     func callMethod(methodName: String, args: [Any]) throws -> Any {

--- a/Sources/UnstoppableDomainsResolution/Helpers/AsyncResolver.swift
+++ b/Sources/UnstoppableDomainsResolution/Helpers/AsyncResolver.swift
@@ -10,7 +10,6 @@
 
 internal class AsyncResolver {
 
-    typealias ResultConsumer<T> = (T?, Error?)
     typealias GeneralFunction<T> = () throws -> T
 
     let asyncGroup = DispatchGroup()
@@ -52,8 +51,8 @@ internal class AsyncResolver {
     }
 
     private func parseResult<T>(_ results: [UNSLocation: ResultConsumer<T>] ) throws -> T {
-        let l2Result = results[.layer2]!
-        let l1Result = results[.layer1]!
+        let l2Result = Utillities.getLayerResultWrapper(from: results, for: .layer2)
+        let l1Result = Utillities.getLayerResultWrapper(from: results, for: .layer1)
 
         if let l2error = l2Result.1 {
             if !isUnregisteredDomain(error: l2error) {

--- a/Sources/UnstoppableDomainsResolution/Helpers/Types.swift
+++ b/Sources/UnstoppableDomainsResolution/Helpers/Types.swift
@@ -15,6 +15,7 @@ public typealias DictionaryLocationResultConsumer = (Result<[String: Location], 
 public typealias DnsRecordsResultConsumer = (Result<[DnsRecord], Error>) -> Void
 public typealias TokenUriMetadataResultConsumer = (Result<TokenUriMetadata, ResolutionError>) -> Void
 public typealias BoolResultConsumer = (Result<Bool, Error>) -> Void
+public typealias ResultConsumer<T> = (T?, Error?)
 
 public enum NamingServiceName: String {
     case uns
@@ -33,13 +34,13 @@ public struct UNSContract {
     let deploymentBlock: String
 }
 
-public struct Location {
-    let registryAddress: String
-    let resolverAddress: String
-    let networkId: String
-//    let blockchain: String
-    let owner: String
-    let providerURL: String
+public struct Location: Equatable {
+    var registryAddress: String?
+    var resolverAddress: String?
+    var networkId: String?
+    var blockchain: String?
+    var owner: String?
+    var providerURL: String?
 }
 
 public let ethCoinIndex = 60

--- a/Sources/UnstoppableDomainsResolution/Helpers/Types.swift
+++ b/Sources/UnstoppableDomainsResolution/Helpers/Types.swift
@@ -11,6 +11,7 @@ import Foundation
 public typealias StringResultConsumer = (Result<String, ResolutionError>) -> Void
 public typealias StringsArrayResultConsumer = (Result<[String?], ResolutionError>) -> Void
 public typealias DictionaryResultConsumer = (Result<[String: String], ResolutionError>) -> Void
+public typealias DictionaryLocationResultConsumer = (Result<[String: Location], ResolutionError>) -> Void
 public typealias DnsRecordsResultConsumer = (Result<[DnsRecord], Error>) -> Void
 public typealias TokenUriMetadataResultConsumer = (Result<TokenUriMetadata, ResolutionError>) -> Void
 public typealias BoolResultConsumer = (Result<Bool, Error>) -> Void
@@ -31,4 +32,14 @@ public struct UNSContract {
     let contract: Contract
     let deploymentBlock: String
 }
+
+public struct Location {
+    let registryAddress: String
+    let resolverAddress: String
+    let networkId: String
+//    let blockchain: String
+    let owner: String
+    let providerURL: String
+}
+
 public let ethCoinIndex = 60

--- a/Sources/UnstoppableDomainsResolution/Helpers/Utilities.swift
+++ b/Sources/UnstoppableDomainsResolution/Helpers/Utilities.swift
@@ -25,6 +25,15 @@ internal class Utillities {
     static func isNotEmpty(_ array: [Any]) -> Bool {
         return array.count > 0
     }
+
+    static func getLayerResultWrapper<T>(from results: [UNSLocation: ResultConsumer<T>], for location: UNSLocation) -> ResultConsumer<T> {
+        return results[location]!
+    }
+
+    static func getLayerResult<T>(from results: [UNSLocation: ResultConsumer<T>], for location: UNSLocation) -> T {
+        let wrapper = Self.getLayerResultWrapper(from: results, for: location)
+        return wrapper.0!
+    }
 }
 
 extension String {

--- a/Sources/UnstoppableDomainsResolution/NamingServices/ENS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/ENS.swift
@@ -113,6 +113,10 @@ internal class ENS: CommonNamingService, NamingService {
         throw ResolutionError.methodNotSupported
     }
 
+    func locations(domains: [String]) throws -> [String: Location] {
+        throw ResolutionError.methodNotSupported
+    }
+
     // MARK: - get Resolver
     func resolver(domain: String) throws -> String {
         let tokenId = super.namehash(domain: domain)

--- a/Sources/UnstoppableDomainsResolution/NamingServices/UNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/UNS.swift
@@ -138,6 +138,13 @@ internal class UNS: CommonNamingService, NamingService {
         )
     }
 
+    func locations(domains: [String]) throws -> [String: Location] {
+        return try asyncResolver.safeResolve(
+            l1func: self.layer1.locations(domains: domains),
+            l2func: self.layer2.locations(domains: domains)
+        )
+    }
+
     func tokensOwnedBy(address: String) throws -> [String] {
         let results = try asyncResolver.resolve(
             l1func: self.layer1.tokensOwnedBy(address: address),

--- a/Sources/UnstoppableDomainsResolution/NamingServices/UNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/UNS.swift
@@ -29,6 +29,116 @@ internal class UNS: CommonNamingService, NamingService {
         }
     }
 
+    func isSupported(domain: String) -> Bool {
+        return layer2.isSupported(domain: domain)
+    }
+
+    func owner(domain: String) throws -> String {
+        return try asyncResolver.safeResolve(
+            l1func: self.layer1.owner(domain: domain),
+            l2func: self.layer2.owner(domain: domain)
+        )
+    }
+
+    func record(domain: String, key: String) throws -> String {
+        return try asyncResolver.safeResolve(
+            l1func: self.layer1.record(domain: domain, key: key),
+            l2func: self.layer2.record(domain: domain, key: key)
+        )
+    }
+
+    func records(keys: [String], for domain: String) throws -> [String: String] {
+        return try asyncResolver.safeResolve(
+            l1func: self.layer1.records(keys: keys, for: domain),
+            l2func: self.layer2.records(keys: keys, for: domain)
+        )
+    }
+
+    func getTokenUri(tokenId: String) throws -> String {
+        return try asyncResolver.safeResolve(
+            l1func: self.layer1.getTokenUri(tokenId: tokenId),
+            l2func: self.layer2.getTokenUri(tokenId: tokenId)
+        )
+    }
+
+    func getDomainName(tokenId: String) throws -> String {
+        return try asyncResolver.safeResolve(
+            l1func: self.layer1.getDomainName(tokenId: tokenId),
+            l2func: self.layer2.getDomainName(tokenId: tokenId)
+        )
+    }
+
+    func addr(domain: String, ticker: String) throws -> String {
+        return try asyncResolver.safeResolve(
+            l1func: self.layer1.addr(domain: domain, ticker: ticker),
+            l2func: self.layer2.addr(domain: domain, ticker: ticker)
+        )
+    }
+
+    func resolver(domain: String) throws -> String {
+        return try asyncResolver.safeResolve(
+            l1func: self.layer1.resolver(domain: domain),
+            l2func: self.layer2.resolver(domain: domain)
+        )
+    }
+
+    func locations(domains: [String]) throws -> [String: Location] {
+        let results = try asyncResolver.resolve(
+            l1func: self.layer1.locations(domains: domains),
+            l2func: self.layer2.locations(domains: domains)
+        )
+        try self.throwIfLayerHasError(results)
+
+        var locations: [String: Location] = [:]
+        let l2Response = Utillities.getLayerResult(from: results, for: .layer2)
+        let l1Response = Utillities.getLayerResult(from: results, for: .layer1)
+
+        domains.forEach {
+            let l2Loc = l2Response[$0]!
+            let l1Loc = l1Response[$0]!
+
+            locations[$0] = l2Loc.owner == nil ? l1Loc : l2Loc
+        }
+
+        return locations
+    }
+
+    func tokensOwnedBy(address: String) throws -> [String] {
+        let results = try asyncResolver.resolve(
+            l1func: self.layer1.tokensOwnedBy(address: address),
+            l2func: self.layer2.tokensOwnedBy(address: address)
+        )
+        var tokens: [String] = []
+
+        try self.throwIfLayerHasError(results)
+
+        let l2Results = Utillities.getLayerResult(from: results, for: .layer2)
+        let l1Results = Utillities.getLayerResult(from: results, for: .layer1)
+
+        tokens += l2Results
+        tokens += l1Results
+
+        return tokens.uniqued()
+    }
+
+    func batchOwners(domains: [String]) throws -> [String?] {
+        let results = try asyncResolver.resolve(
+            l1func: self.layer1.batchOwners(domains: domains),
+            l2func: self.layer2.batchOwners(domains: domains)
+        )
+        try self.throwIfLayerHasError(results)
+
+        var owners: [String?] = []
+        let l2Result = Utillities.getLayerResult(from: results, for: .layer2)
+        let l1Result = Utillities.getLayerResult(from: results, for: .layer1)
+
+        for (l2owner, l1owner) in zip(l2Result, l1Result) {
+            let ownerAddress = l2owner == nil ? l1owner : l2owner
+            owners.append(ownerAddress)
+        }
+        return owners
+    }
+
     private func parseContractAddresses(config: NamingServiceConfig) throws -> [UNSContract] {
         var contracts: [UNSContract] = []
         var proxyReaderContract: UNSContract?
@@ -85,75 +195,10 @@ internal class UNS: CommonNamingService, NamingService {
         return nil
     }
 
-    func isSupported(domain: String) -> Bool {
-        return layer2.isSupported(domain: domain)
-    }
-
-    func owner(domain: String) throws -> String {
-        return try asyncResolver.safeResolve(
-            l1func: self.layer1.owner(domain: domain),
-            l2func: self.layer2.owner(domain: domain)
-        )
-    }
-
-    func record(domain: String, key: String) throws -> String {
-        return try asyncResolver.safeResolve(
-            l1func: self.layer1.record(domain: domain, key: key),
-            l2func: self.layer2.record(domain: domain, key: key)
-        )
-    }
-
-    func records(keys: [String], for domain: String) throws -> [String: String] {
-        return try asyncResolver.safeResolve(
-            l1func: self.layer1.records(keys: keys, for: domain),
-            l2func: self.layer2.records(keys: keys, for: domain)
-        )
-    }
-
-    func getTokenUri(tokenId: String) throws -> String {
-        return try asyncResolver.safeResolve(
-            l1func: self.layer1.getTokenUri(tokenId: tokenId),
-            l2func: self.layer2.getTokenUri(tokenId: tokenId)
-        )
-    }
-
-    func getDomainName(tokenId: String) throws -> String {
-        return try asyncResolver.safeResolve(
-            l1func: self.layer1.getDomainName(tokenId: tokenId),
-            l2func: self.layer2.getDomainName(tokenId: tokenId)
-        )
-    }
-
-    func addr(domain: String, ticker: String) throws -> String {
-        return try asyncResolver.safeResolve(
-            l1func: self.layer1.addr(domain: domain, ticker: ticker),
-            l2func: self.layer2.addr(domain: domain, ticker: ticker)
-        )
-    }
-
-    func resolver(domain: String) throws -> String {
-        return try asyncResolver.safeResolve(
-            l1func: self.layer1.resolver(domain: domain),
-            l2func: self.layer2.resolver(domain: domain)
-        )
-    }
-
-    func locations(domains: [String]) throws -> [String: Location] {
-        return try asyncResolver.safeResolve(
-            l1func: self.layer1.locations(domains: domains),
-            l2func: self.layer2.locations(domains: domains)
-        )
-    }
-
-    func tokensOwnedBy(address: String) throws -> [String] {
-        let results = try asyncResolver.resolve(
-            l1func: self.layer1.tokensOwnedBy(address: address),
-            l2func: self.layer2.tokensOwnedBy(address: address)
-        )
-        var tokens: [String] = []
-
-        let l2Results = results[.layer2]!
-        let l1Results = results[.layer1]!
+    // This is used only when both layers should not throw any errors. Methods like batchOwners or locations require both layers.
+    private func throwIfLayerHasError<T>(_ results: [UNSLocation: ResultConsumer<T>]) throws {
+        let l2Results = Utillities.getLayerResultWrapper(from: results, for: .layer2)
+        let l1Results = Utillities.getLayerResultWrapper(from: results, for: .layer1)
 
         guard l2Results.1 == nil else {
             throw l2Results.1!
@@ -162,35 +207,6 @@ internal class UNS: CommonNamingService, NamingService {
         guard l1Results.1 == nil else {
             throw l1Results.1!
         }
-
-        tokens += l2Results.0!
-        tokens += l1Results.0!
-
-        return tokens.uniqued()
-    }
-
-    func batchOwners(domains: [String]) throws -> [String?] {
-        let results = try asyncResolver.resolve(
-            l1func: self.layer1.batchOwners(domains: domains),
-            l2func: self.layer2.batchOwners(domains: domains)
-        )
-        var owners: [String?] = []
-        let l2Result = results[.layer2]!
-        let l1Result = results[.layer1]!
-
-        guard l2Result.1 == nil else {
-            throw l2Result.1!
-        }
-
-        guard l1Result.1 == nil else {
-            throw l1Result.1!
-        }
-
-        for (l2owner, l1owner) in zip(l2Result.0!, l1Result.0!) {
-            let ownerAddress = l2owner == nil ? l1owner : l2owner
-            owners.append(ownerAddress)
-        }
-        return owners
     }
 }
 

--- a/Sources/UnstoppableDomainsResolution/NamingServices/UNSLayer.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/UNSLayer.swift
@@ -262,6 +262,10 @@ internal class UNSLayer: CommonNamingService, NamingService {
         throw ResolutionError.recordNotFound
     }
 
+    func locations(domains: [String]) throws -> [String: Location] {
+        return [:]
+    }
+
     func getTokenUri(tokenId: String) throws -> String {
         do {
             if let result = try proxyReaderContract?

--- a/Sources/UnstoppableDomainsResolution/NamingServices/ZNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/ZNS.swift
@@ -87,6 +87,10 @@ internal class ZNS: CommonNamingService, NamingService {
         throw ResolutionError.methodNotSupported
     }
 
+    func locations(domains: [String]) throws -> [String: Location] {
+        throw ResolutionError.methodNotSupported
+    }
+
     // MARK: - get Resolver
     func resolver(domain: String) throws -> String {
         let recordAddresses = try self.recordsAddresses(domain: domain)

--- a/Sources/UnstoppableDomainsResolution/Protocols/NamingService.swift
+++ b/Sources/UnstoppableDomainsResolution/Protocols/NamingService.swift
@@ -29,4 +29,6 @@ protocol NamingService {
     func getTokenUri(tokenId: String) throws -> String
 
     func getDomainName(tokenId: String) throws -> String
+
+    func locations(domains: [String]) throws -> [String: Location]
 }

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -387,6 +387,19 @@ public class Resolution {
         }
     }
 
+    public func locations(domains: [String], completion: @escaping DictionaryLocationResultConsumer) {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            do {
+                let preparedDomains = try domains.map({ (try self?.prepare(domain: $0))! })
+                if let result = try self?.getServiceOf(domains: preparedDomains).locations(domains: preparedDomains) {
+                    completion(.success(result))
+                }
+            } catch {
+                self?.catchError(error, completion: completion)
+            }
+        }
+    }
+
     // MARK: - Uttilities function
 
     /// this returns [NamingService] from the configurations
@@ -522,6 +535,14 @@ public class Resolution {
 
     /// Process the 'error'
     private func catchError(_ error: Error, completion:@escaping TokenUriMetadataResultConsumer ) {
+        guard let catched = error as? ResolutionError else {
+            completion(.failure(.unknownError(error)))
+            return
+        }
+        completion(.failure(catched))
+    }
+
+    private func catchError(_ error: Error, completion:@escaping DictionaryLocationResultConsumer ) {
         guard let catched = error as? ResolutionError else {
             completion(.failure(.unknownError(error)))
             return

--- a/Sources/UnstoppableDomainsResolution/Resources/UNS/unsProxyReader.json
+++ b/Sources/UnstoppableDomainsResolution/Resources/UNS/unsProxyReader.json
@@ -2,12 +2,12 @@
   {
     "inputs": [
       {
-        "internalType": "contract IRegistry",
+        "internalType": "contract IUNSRegistry",
         "name": "unsRegistry",
         "type": "address"
       },
       {
-        "internalType": "contract ICryptoRegistry",
+        "internalType": "contract ICNSRegistry",
         "name": "cnsRegistry",
         "type": "address"
       }
@@ -420,6 +420,25 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "data",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "multicall",
+    "outputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "results",
+        "type": "bytes[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -866,6 +866,71 @@ class ResolutionTests: XCTestCase {
         assert(values["someweirdstuf"] == "")
     }
 
+    func testLocations() throws {
+        let locationsReceived = expectation(description: "Locations for each domain should be received");
+        let domains = [
+            TestHelpers.getTestDomain(.DOMAIN),
+            TestHelpers.getTestDomain(.LAYER2_DOMAIN),
+            TestHelpers.getTestDomain(.COIN_DOMAIN),
+            TestHelpers.getTestDomain(.UNREGISTERED_DOMAIN)
+        ];
+        
+        var locations: [String: Location] = [:];
+        resolution.locations(domains: domains) { result in
+            switch result {
+            case .success(let returnValue):
+                locationsReceived.fulfill()
+                locations = returnValue;
+            case .failure(let error):
+                XCTFail("Expected locations, but got \(error)");
+            }
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil);
+        
+        let answers: [String: Location] = [
+            TestHelpers.getTestDomain(.UNREGISTERED_DOMAIN): Location(
+                registryAddress: nil,
+                resolverAddress: nil,
+                networkId: nil,
+                blockchain: nil,
+                owner: nil,
+                providerURL: nil
+            ),
+            TestHelpers.getTestDomain(.DOMAIN): Location(
+                registryAddress: "0xaad76bea7cfec82927239415bb18d2e93518ecbb",
+                resolverAddress: "0x95AE1515367aa64C462c71e87157771165B1287A",
+                networkId: "4",
+                blockchain: "ETH",
+                owner: "0xe7474D07fD2FA286e7e0aa23cd107F8379085037",
+                providerURL: "https://rinkeby.infura.io/v3/3c25f57353234b1b853e9861050f4817"
+            ),
+            TestHelpers.getTestDomain(.COIN_DOMAIN):Location(
+                registryAddress: "0x7fb83000b8ed59d3ead22f0d584df3a85fbc0086",
+                resolverAddress: "0x7fb83000B8eD59D3eAD22f0D584Df3a85fBC0086",
+                networkId: "4",
+                blockchain: "ETH",
+                owner: "0xe7474D07fD2FA286e7e0aa23cd107F8379085037",
+                providerURL: "https://rinkeby.infura.io/v3/3c25f57353234b1b853e9861050f4817"
+            ),
+            TestHelpers.getTestDomain(.LAYER2_DOMAIN): Location(
+                registryAddress: "0x2a93c52e7b6e7054870758e15a1446e769edfb93",
+                resolverAddress: "0x2a93C52E7B6E7054870758e15A1446E769EdfB93",
+                networkId: "80001",
+                blockchain: "MATIC",
+                owner: "0xe7474D07fD2FA286e7e0aa23cd107F8379085037",
+                providerURL: "https://matic-testnet-archive-rpc.bwarelabs.com"
+            ),
+        ];
+        
+        assert(!locations.isEmpty);
+        assert(locations.count == domains.count);
+        domains.forEach { domain in
+            assert(locations[domain] == answers[domain])
+        }
+    }
+    
+    
     func testCheckDomain() throws {
         // Given
         let validDomainName: String = "valid.domain-test-123.crypto"


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/179624532

This PR introduces Resolution#locations method. It takes a list of domains and for each domain, it returns the corresponding Location object:

```swift
public struct Location: Equatable {
    var registryAddress: String?
    var resolverAddress: String?
    var networkId: String?
    var blockchain: String?
    var owner: String?
    var providerURL: String?
}
```

P.S. This PR should be merged after #56. I have set up the base to #56 to make it easier for review. This PR starts from commit `#ff0f4e1`
