### PR TITLE
Johnny/allRecords

### DIFF
--- a/Sources/UnstoppableDomainsResolution/ContractZNS.swift
+++ b/Sources/UnstoppableDomainsResolution/ContractZNS.swift
@@ -31,15 +31,21 @@ internal class ContractZNS {
                 ParamElement.array(keys.map { ParamElement.string($0) })
             ]
         )
-        let response = try postRequest(body)!
+        do {
+            let response = try postRequest(body)!
 
-        guard case let ParamElement.dictionary(dict) = response,
-            let results = self.reduce(dict: dict)[field] as? [String: Any] else {
-             print("Invalid response, can't process")
-             return response
+            guard case let ParamElement.dictionary(dict) = response,
+                let results = self.reduce(dict: dict)[field] as? [String: Any] else {
+                 print("Invalid response, can't process")
+                 return response
+            }
+
+            return results
+        // Zilliqa returns null if the domain is not registered,
+        // this causes our decoder to fail and throw APIError.decodingError
+        } catch APIError.decodingError {
+                throw ResolutionError.unregisteredDomain
         }
-
-        return results
     }
 
     private func postRequest(_ body: JsonRpcPayload) throws -> Any? {

--- a/Sources/UnstoppableDomainsResolution/NamingServices/ENS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/ENS.swift
@@ -97,8 +97,11 @@ internal class ENS: CommonNamingService, NamingService {
     }
 
     func records(keys: [String], for domain: String) throws -> [String: String] {
-        // TODO: Add some batch request and collect all keys by few request
-        throw ResolutionError.recordNotSupported
+        throw ResolutionError.methodNotSupported
+    }
+
+    func allRecords(domain: String) throws -> [String: String] {
+        throw ResolutionError.methodNotSupported
     }
 
     func getTokenUri(tokenId: String) throws -> String {

--- a/Sources/UnstoppableDomainsResolution/NamingServices/UNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/UNS.swift
@@ -54,6 +54,13 @@ internal class UNS: CommonNamingService, NamingService {
         )
     }
 
+    func allRecords(domain: String) throws -> [String: String] {
+        return try asyncResolver.safeResolve(
+            l1func: self.layer1.allRecords(domain: domain),
+            l2func: self.layer2.allRecords(domain: domain)
+        )
+    }
+
     func getTokenUri(tokenId: String) throws -> String {
         return try asyncResolver.safeResolve(
             l1func: self.layer1.getTokenUri(tokenId: tokenId),

--- a/Sources/UnstoppableDomainsResolution/NamingServices/ZNS.swift
+++ b/Sources/UnstoppableDomainsResolution/NamingServices/ZNS.swift
@@ -75,6 +75,13 @@ internal class ZNS: CommonNamingService, NamingService {
         return filtered
     }
 
+    func allRecords(domain: String) throws -> [String: String] {
+        guard let records = try self.records(address: try resolver(domain: domain), keys: []) as? [String: String] else {
+            throw ResolutionError.recordNotFound(self.name.rawValue)
+        }
+        return records
+    }
+
     func getTokenUri(tokenId: String) throws -> String {
         throw ResolutionError.methodNotSupported
     }

--- a/Sources/UnstoppableDomainsResolution/Protocols/NamingService.swift
+++ b/Sources/UnstoppableDomainsResolution/Protocols/NamingService.swift
@@ -24,6 +24,7 @@ protocol NamingService {
 
     func record(domain: String, key: String) throws -> String
     func records(keys: [String], for domain: String) throws -> [String: String]
+    func allRecords(domain: String) throws -> [String: String]
 
     func getTokenUri(tokenId: String) throws -> String
 

--- a/Sources/UnstoppableDomainsResolution/Resolution.swift
+++ b/Sources/UnstoppableDomainsResolution/Resolution.swift
@@ -308,12 +308,28 @@ public class Resolution {
     /// Allows to get Many records from a `domain` in a single transaction
     /// - Parameter  domain: - domain name to be resolved
     /// - Parameter  keys: -  is an array of keys
-    /// - Parameter  completion: A callback that resolves `Result`  with an `map [key: value]` for a specific domain or `Error`
+    /// - Parameter  completion: A callback that resolves `Result`  with a `map [key: value]` for a specific domain or `Error`
     public func records(domain: String, keys: [String], completion:@escaping DictionaryResultConsumer ) {
         DispatchQueue.global(qos: .utility).async { [weak self] in
             do {
                 if let preparedDomain = try self?.prepare(domain: domain),
                     let result = try self?.getServiceOf(domain: preparedDomain).records(keys: keys, for: preparedDomain) {
+                    completion(.success(result))
+                }
+            } catch {
+                self?.catchError(error, completion: completion)
+            }
+        }
+    }
+
+    /// Resolves all the records from a domain
+    /// - Parameter domain: - domain name to be resolved
+    /// - Parameter completion: A callback that resolves `Result` with a `map [key: value]` for a specific domain or `Error`
+    public func allRecords(domain: String, completion: @escaping DictionaryResultConsumer) {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            do {
+                if let preparedDomain = try self?.prepare(domain: domain),
+                   let result = try self?.getServiceOf(domain: preparedDomain).allRecords(domain: preparedDomain) {
                     completion(.success(result))
                 }
             } catch {

--- a/Sources/UnstoppableDomainsResolution/Resources/UNS/uns-config.json
+++ b/Sources/UnstoppableDomainsResolution/Resources/UNS/uns-config.json
@@ -14,7 +14,7 @@
                     "address": "0xD1E5b0FF1287aA9f9A268759062E4Ab08b9Dacbe",
                     "legacyAddresses": [],
                     "deploymentBlock": "0x8a958b",
-                    "forwarder": "0x802E1D2d48dA1d36ff2c8E2e376D39b8D1DCA549"
+                    "forwarder": "0x97B0E89fC1B7eD4A8B237D9d8Fcce9b234f25A37"
                 },
                 "MintingManager": {
                     "address": "0x2a7084870bB724175a3C96Da8FaA55128fa3E19D",
@@ -64,7 +64,7 @@
                         "0x878bc2f3f717766ab69c0a5f9a6144931e61aed3"
                     ],
                     "deploymentBlock": "0x960844",
-                    "forwarder": "0xa88541075B3E29C602C3334F8CA8C943F6BD35c1"
+                    "forwarder": "0x92660E5F403679aB45e0C6DB7c35B5629d265fDd"
                 },
                 "ProxyReader": {
                     "address": "0xc3C2BAB5e3e52DBF311b2aAcEf2e40344f19494E",
@@ -103,7 +103,7 @@
                     "address": "0xAad76bea7CFEc82927239415BB18D2e93518ecBB",
                     "legacyAddresses": [],
                     "deploymentBlock": "0x7232bc",
-                    "forwarder": "0x4c46Fb148F2165517E71d6EB5C99c2021e67f068"
+                    "forwarder": "0xdf5CC97216785398D5C77348e68fc9461108f85d"
                 },
                 "MintingManager": {
                     "address": "0xdAAf99A920D31F4f5720e4667b12b24e54A03070",
@@ -150,7 +150,7 @@
                     "address": "0x95AE1515367aa64C462c71e87157771165B1287A",
                     "legacyAddresses": [],
                     "deploymentBlock": "0x7232cf",
-                    "forwarder": "0xB55a783126B1068FeB64dF6f78B2a2063A288b4a"
+                    "forwarder": "0xE172D8557d6F342b1b2976dE784F6Dff6ABC0a37"
                 },
                 "ProxyReader": {
                     "address": "0xE6729D224D00b3dd4FC731C4Ee3274E35Da06578",

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -1099,24 +1099,74 @@ class ResolutionTests: XCTestCase {
         assert(layer2Records["weirdrecord"] == "");
     }
     
-    func testAllRecords() throws {
+    func testAllRecordsErrors() throws {
         let ensIsNotSupportedReceived = expectation(description: "ENS is not supported for this method");
+        let unregisteredUNSDomainReceived = expectation(description: "Unregistered UNS domain should be thrown");
+        let unregisteredZNSDomainReceived = expectation(description: "Unregistered UNS domain should be thrown");
+        
         var ensResult: Result<[String: String], ResolutionError>!;
+        var unsResult: Result<[String: String], ResolutionError>!;
+        var znsResult: Result<[String: String], ResolutionError>!;
         
         resolution.allRecords(domain: TestHelpers.getTestDomain(.ETH_DOMAIN)) { result in
             ensIsNotSupportedReceived.fulfill();
             ensResult = result;
         }
+        
+        resolution.allRecords(domain: TestHelpers.getTestDomain(.UNREGISTERED_DOMAIN)) { result in
+            unregisteredUNSDomainReceived.fulfill();
+            unsResult = result;
+        }
+        
+        resolution.allRecords(domain: TestHelpers.getTestDomain(.UNREGISTERED_ZIL)) { result in
+            unregisteredZNSDomainReceived.fulfill();
+            znsResult = result;
+        }
+        
         waitForExpectations(timeout: timeout, handler: nil);
-        TestHelpers.checkError(result: ensResult, expectedError: .methodNotSupported)
+        TestHelpers.checkError(result: ensResult, expectedError: .methodNotSupported);
+        TestHelpers.checkError(result: unsResult, expectedError: .unregisteredDomain);
+        TestHelpers.checkError(result: znsResult, expectedError: .unregisteredDomain);
+    }
+    
+    func testAllRecords() throws {
+        
+        let receievedAllRecordsFromUnsDomain = expectation(description: "Should receieve all records from uns domain");
+        var unsDomainRecords: [String: String]!;
+        
+        resolution.allRecords(domain: TestHelpers.getTestDomain(.DOMAIN)) { result in
+            switch result {
+            case .success(let returnValue):
+                unsDomainRecords = returnValue;
+                receievedAllRecordsFromUnsDomain.fulfill();
+            case .failure(let error):
+                XCTFail("Expected all records from uns domain, but got \(error)");
+            }
+        }
+        
+        
+        waitForExpectations(timeout: timeout, handler: nil);
+        let expectedRecords: [String: String] = [
+            "dns.ttl": "128",
+            "dns.A.ttl": "98",
+            "dns.A": "[\"10.0.0.1\", \"10.0.0.3\"]",
+            "crypto.USDT.version.OMNI.address": "19o6LvAdCPkjLi83VsjrCsmvQZUirT4KXJ",
+            "crypto.USDT.version.TRON.address": "TNemhXhpX7MwzZJa3oXvfCjo5pEeXrfN2h",
+            "custom.record": "custom.value",
+            "dweb.ipfs.hash": "QmdyBw5oTgCtTLQ18PbDvPL8iaLoEPhSyzD91q9XmgmAjb",
+            "crypto.ETH.address": "0x8aaD44321A86b170879d7A244c1e8d360c99DdA8",
+            "dns.AAAA": "[]",
+            "gundb.username.value": "0x8912623832e174f2eb1f59cc3b587444d619376ad5bf10070e937e0dc22b9ffb2e3ae059e6ebf729f87746b2f71e5d88ec99c1fb3c7c49b8617e2520d474c48e1c",
+            "crypto.USDT.version.ERC20.address": "0xe7474D07fD2FA286e7e0aa23cd107F8379085037",
+            "ipfs.html.value": "QmdyBw5oTgCtTLQ18PbDvPL8iaLoEPhSyzD91q9XmgmAjb",
+            "crypto.USDT.version.EOS.address": "letsminesome"
+        ];
+        assert(expectedRecords == unsDomainRecords);
     }
     
     func testZilAllRecords() throws {
         let recordsReceived = expectation(description: "Zilliqa records should be received");
-        let zilErrorReceived = expectation(description: "Should return unregistered domain");
-        
         var zilRecords: [String: String] = [:]
-        var zilErrorResult: Result<[String: String], ResolutionError>!;
         
         resolution.allRecords(domain: TestHelpers.getTestDomain(.ZIL_DOMAIN)) { result in
             switch result {
@@ -1128,14 +1178,8 @@ class ResolutionTests: XCTestCase {
             }
         }
 
-        resolution.allRecords(domain: "unregistered.zil") { result in
-            zilErrorReceived.fulfill();
-            zilErrorResult = result;
-        }
-        
         waitForExpectations(timeout: timeout, handler: nil);
-        TestHelpers.checkError(result: zilErrorResult, expectedError: .unregisteredDomain);
-        
+
         let expectedRecords: [String: String] = [
             "ZIL": "zil1tcucw4w5uqgwz38y2na4249adzeg4rvl94kwhm",
             "crypto.ETH.address": "0x084Ac37CDEfE1d3b68a63c08B203EFc3ccAB9742"

--- a/Tests/ResolutionTests/TestHelpers.swift
+++ b/Tests/ResolutionTests/TestHelpers.swift
@@ -24,6 +24,7 @@ class TestHelpers {
         case DOMAIN3
         case COIN_DOMAIN
         case UNREGISTERED_DOMAIN
+        case UNREGISTERED_ZIL
         case RINKEBY_DOMAIN
         case ETH_DOMAIN
         case UNSPECIFIED_RESOLVER_DOMAIN
@@ -39,6 +40,7 @@ class TestHelpers {
         .DOMAIN3: "brad.crypto",
         .COIN_DOMAIN: "udtestdev-johnnycoin.coin",
         .UNREGISTERED_DOMAIN: "unregistered.crypto",
+        .UNREGISTERED_ZIL: "unregistered.zil",
         .RINKEBY_DOMAIN: "udtestdev-creek.crypto",
         .ETH_DOMAIN: "monkybrain.eth",
         .UNSPECIFIED_RESOLVER_DOMAIN: "twistedmusic.crypto",


### PR DESCRIPTION
Pivotal story: https://www.pivotaltracker.com/story/show/179705042

Same as [java version](https://github.com/unstoppabledomains/resolution-java/pull/67)
Introducing allRecords method which combines records from [resolver-keys.json](https://github.com/unstoppabledomains/uns/blob/main/resolver-keys.json) with any records from tokenURI metadata before getting the value from smart contract to minimize missed records.

resolver-keys.json is just like the uns network config set to be downloaded on each build allowing us to be sure to have the latest file
<img width="1061" alt="Screen Shot 2021-10-27 at 5 20 38 PM" src="https://user-images.githubusercontent.com/16522024/139084620-bdaf21da-fd4b-4841-990f-470661c35d90.png">

Also found out that Zns was broken. instead of unregistered Domains when needed it threw an ApiError.decoding error. Zilliqa blockchain returns null for the "result" property of a json rpc answer when we are querying for an unregistered token.
This behavior confuses our API decoder making him to threw the APIError.decodingError. 

I fixed it and added unit tests to fix the behavior. 



