### PR TITLE
Add test for owner without resolver

### DIFF
--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -902,11 +902,13 @@ class ResolutionTests: XCTestCase {
         // Given
         let layer2OwnerReceived = expectation(description: "Domain should return owner address on layer2");
         let layer1OwnerReceived = expectation(description: "Domain should return owner address on layer1");
+        let unconfiguredOwnerReceived = expectation(description: "Unconfigured domain should be received");
         let unregisteredReceived = expectation(description: "Unregistered domain should be received");
         
 
         var layer2Owner = ""
         var layer1Owner = ""
+        var unconfiguredOwner = ""
         var unregisteredResult: Result<String, ResolutionError>!
 
         // When
@@ -930,6 +932,16 @@ class ResolutionTests: XCTestCase {
             }
         }
         
+        resolution.owner(domain: TestHelpers.getTestDomain(.UNSPECIFIED_RESOLVER_DOMAIN)) { (result) in
+            switch result {
+            case .success(let returnValue):
+                unconfiguredOwnerReceived.fulfill();
+                unconfiguredOwner = returnValue;
+            case .failure(let error):
+                XCTFail("Expected owner from unconfigured domain, but got \(error)")
+            }
+        }
+
         resolution.owner(domain: TestHelpers.getTestDomain(.UNREGISTERED_DOMAIN)) {
             unregisteredResult = $0
             unregisteredReceived.fulfill()
@@ -940,6 +952,7 @@ class ResolutionTests: XCTestCase {
         // Then
         assert(layer2Owner.lowercased() == "0xe7474D07fD2FA286e7e0aa23cd107F8379085037".lowercased())
         assert(layer1Owner.lowercased() == "0xe7474D07fD2FA286e7e0aa23cd107F8379085037".lowercased())
+        assert(unconfiguredOwner.lowercased() == "0x58ca45e932a88b2e7d0130712b3aa9fb7c5781e2".lowercased())
         TestHelpers.checkError(result: unregisteredResult, expectedError: ResolutionError.unregisteredDomain)
     }
     

--- a/Tests/ResolutionTests/ResolutionTests.swift
+++ b/Tests/ResolutionTests/ResolutionTests.swift
@@ -75,13 +75,6 @@ class ResolutionTests: XCTestCase {
     }
     
     func testForUnspecifiedResolver() throws {
-        resolution = try Resolution(configs: Configurations(
-                    uns: UnsLocations(
-                        layer1: NamingServiceConfig(providerUrl: "https://mainnet.infura.io/v3/3c25f57353234b1b853e9861050f4817",
-                                                    network: "mainnet"),
-                        layer2:NamingServiceConfig(providerUrl: "https://matic-testnet-archive-rpc.bwarelabs.com",
-                                                    network: "polygon-mumbai") )
-        ))
         let UnregirestedDomainExpectation = expectation(description: "Domain should not have a Resolver!")
         var NoRecordResult: Result<String, ResolutionError>!
         resolution.addr(domain: TestHelpers.getTestDomain(.UNSPECIFIED_RESOLVER_DOMAIN), ticker: "eth") {

--- a/Tests/ResolutionTests/TestHelpers.swift
+++ b/Tests/ResolutionTests/TestHelpers.swift
@@ -43,7 +43,7 @@ class TestHelpers {
         .UNREGISTERED_ZIL: "unregistered.zil",
         .RINKEBY_DOMAIN: "udtestdev-creek.crypto",
         .ETH_DOMAIN: "monkybrain.eth",
-        .UNSPECIFIED_RESOLVER_DOMAIN: "twistedmusic.crypto",
+        .UNSPECIFIED_RESOLVER_DOMAIN: "udtestdev-d0137c.crypto",
         .ZIL_DOMAIN: "test-udtesting-654.zil",
         .LAYER2_DOMAIN: "udtestdev-johnnytest.wallet"
             


### PR DESCRIPTION
## Related story
https://www.pivotaltracker.com/story/show/180170102

## Changes
  - Added test. The method actually works as intended.